### PR TITLE
use multihash instead of CID bytes. return records without address.

### DIFF
--- a/lib/src/dht/dht.dart
+++ b/lib/src/dht/dht.dart
@@ -39,8 +39,6 @@ import 'package:dart_libp2p_kad_dht/src/record/ipns_validator.dart';
 import 'package:dart_libp2p_kad_dht/src/record/namespace_validator.dart';
 import 'package:dart_libp2p_kad_dht/src/record/pubkey.dart';
 
-
-
 /// Exception thrown when DHT message retries are exhausted.
 class MaxRetriesExceededException implements Exception {
   final String message;
@@ -64,10 +62,9 @@ class SimplePeerLatencyMetrics implements PeerLatencyMetrics {
   /// Default latency to return for all peers
   final Duration defaultLatency;
 
-
-
   /// Creates a new SimplePeerLatencyMetrics with the given default latency
-  SimplePeerLatencyMetrics({this.defaultLatency = const Duration(milliseconds: 100)});
+  SimplePeerLatencyMetrics(
+      {this.defaultLatency = const Duration(milliseconds: 100)});
 
   @override
   Duration latencyEWMA(PeerId peerId) {
@@ -80,10 +77,11 @@ class SimplePeerLatencyMetrics implements PeerLatencyMetrics {
 // /// Type definition for a stream handler function
 // typedef StreamHandler = Future<void> Function(dynamic stream, PeerId remotePeer);
 
-
 /// DHT is the main implementation of the Kademlia DHT for libp2p.
-class IpfsDHT implements Routing, Discovery { // Added Discovery interface
+class IpfsDHT implements Routing, Discovery {
+  // Added Discovery interface
   static final _log = Logger('IpfsDHT');
+
   /// The host that this DHT is running on
   final Host _host;
 
@@ -133,17 +131,17 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   /// Set to track active QueryRunner instances for proper cleanup
   final Set<QueryRunner> _activeQueryRunners = <QueryRunner>{};
 
-  DHTHandlers get handlers => _handlers; // Flag to ensure background bootstrap tasks are only initiated once
+  DHTHandlers get handlers =>
+      _handlers; // Flag to ensure background bootstrap tasks are only initiated once
 
   // or managed correctly if bootstrap is called multiple times.
   bool _backgroundTasksInitiated = false;
-  
+
   /// Completer to control auto mode checking
   Completer<void>? _autoModeCompleter;
-  
+
   /// Completer to control background refresh
   Completer<void>? _backgroundRefreshCompleter;
-
 
   /// Local datastore for key-value pairs
   final Map<String, Record> _datastore = {};
@@ -153,7 +151,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     required Host host,
     required ProviderStore providerStore,
     DHTOptions? options,
-    NamespacedValidator? validator, // Optional: allow passing a pre-configured one
+    NamespacedValidator?
+        validator, // Optional: allow passing a pre-configured one
   })  : _host = host,
         _routingTable = RoutingTable(
           local: host.id,
@@ -164,11 +163,14 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
         ),
         _providerManager = ProviderManager(
           localPeerId: host.id,
-          peerStore: host.peerStore, // Assuming the network implements PeerStore
+          peerStore:
+              host.peerStore, // Assuming the network implements PeerStore
           store: providerStore,
           options: ProviderManagerOptions(
-            provideValidity: options?.provideValidity ?? AminoConstants.defaultProvideValidity,
-            providerAddrTTL: options?.providerAddrTTL ?? AminoConstants.defaultProviderAddrTTL,
+            provideValidity: options?.provideValidity ??
+                AminoConstants.defaultProvideValidity,
+            providerAddrTTL: options?.providerAddrTTL ??
+                AminoConstants.defaultProviderAddrTTL,
           ),
         ),
         _mode = options?.mode ?? DHTMode.auto,
@@ -177,14 +179,14 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     _recordValidator = validator ?? NamespacedValidator();
     // Configure _recordValidator with specific validators
     _recordValidator['pk'] = PublicKeyValidator(); // Namespace without slashes
-    _recordValidator['ipns'] = IpnsValidator(host.peerStore); // Namespace without slashes
+    _recordValidator['ipns'] =
+        IpnsValidator(host.peerStore); // Namespace without slashes
     _recordValidator['v'] = GenericValidator(); // Namespace without slashes
     _nsEstimator = Estimator(
       localId: host.id,
       rt: _routingTable,
       bucketSize: options?.bucketSize ?? AminoConstants.defaultBucketSize,
     );
-
 
     if (options?.autoRefresh ?? false) {
       _refreshManager = RtRefreshManager(
@@ -232,7 +234,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
 
     // If in auto mode, set up periodic checking to switch to server mode
     if (_mode == DHTMode.auto) {
-      _log.info('$logPrefix Mode is auto, starting periodic check for switch to server mode.');
+      _log.info(
+          '$logPrefix Mode is auto, starting periodic check for switch to server mode.');
       _autoModeCompleter = Completer<void>();
       _startAutoModeChecker();
     }
@@ -240,57 +243,70 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     // Subscribe to local address changes to trigger a bootstrap (self-walk)
     // This is crucial for the DHT to update its view of the network when its own addresses change.
     print('[IpfsDHT.start] Subscribing to EvtLocalAddressesUpdated...');
-    _addressUpdateSubscription = _host.eventBus.subscribe(EvtLocalAddressesUpdated).stream.listen((event) {
-      print('[IpfsDHT.start] Received event from eventBus: ${event.runtimeType}');
+    _addressUpdateSubscription = _host.eventBus
+        .subscribe(EvtLocalAddressesUpdated)
+        .stream
+        .listen((event) {
+      print(
+          '[IpfsDHT.start] Received event from eventBus: ${event.runtimeType}');
       // Cast the event, as the stream from subscribe might be Stream<dynamic> or Stream<Object>
       if (event is EvtLocalAddressesUpdated) {
-        if (!_closed && _started) { // Ensure DHT is active and not closed
+        if (!_closed && _started) {
+          // Ensure DHT is active and not closed
           // Using a print statement for now to observe this path being taken during tests.
           // Consider a more formal logging mechanism for production.
-          print('IpfsDHT: Detected local address update. Triggering bootstrap/self-walk.');
+          print(
+              'IpfsDHT: Detected local address update. Triggering bootstrap/self-walk.');
           bootstrap().then((_) {
             print('IpfsDHT: Bootstrap after address update completed.');
-          }).catchError((e, s) { // Added StackTrace
-            print('IpfsDHT: Error during bootstrap triggered by address update: $e\n$s');
+          }).catchError((e, s) {
+            // Added StackTrace
+            print(
+                'IpfsDHT: Error during bootstrap triggered by address update: $e\n$s');
             // Potentially log this error more formally
           });
         }
       }
     });
-    
+
     // Start the refresh manager if it exists
     if (_refreshManager != null) {
       _refreshManager!.start();
       _log.info('$logPrefix RtRefreshManager started');
       await _refreshManager!.refresh(true);
     }
-    
-    print('[IpfsDHT.start] Subscribed to EvtLocalAddressesUpdated. Start method continuing.');
+
+    print(
+        '[IpfsDHT.start] Subscribed to EvtLocalAddressesUpdated. Start method continuing.');
   }
 
   /// Starts the auto mode checker using Future.delayed instead of Timer.periodic.
   /// This prevents unhandled exceptions that can occur with Timer callbacks.
   void _startAutoModeChecker() async {
-    final logPrefix = '[${_host.id.toBase58().substring(0, 6)}.autoModeChecker]';
+    final logPrefix =
+        '[${_host.id.toBase58().substring(0, 6)}.autoModeChecker]';
     try {
       while (!_closed && _started && _mode == DHTMode.auto) {
         await Future.any([
           Future.delayed(Duration(minutes: 1)),
           _autoModeCompleter!.future,
         ]);
-        
+
         if (_closed || !_started || _mode != DHTMode.auto) {
-          _log.fine('$logPrefix DHT closed or mode changed, stopping auto mode checker.');
+          _log.fine(
+              '$logPrefix DHT closed or mode changed, stopping auto mode checker.');
           break;
         }
 
         try {
           final tableSize = await _routingTable.size();
-          _log.finer('$logPrefix Auto mode check: current table size = $tableSize, serverModeMinPeers = ${AminoConstants.serverModeMinPeers}');
-          
+          _log.finer(
+              '$logPrefix Auto mode check: current table size = $tableSize, serverModeMinPeers = ${AminoConstants.serverModeMinPeers}');
+
           // Switch to server mode if we have enough peers in our routing table
           if (tableSize >= AminoConstants.serverModeMinPeers) {
-            _log.info('$logPrefix Auto mode: table size ($tableSize) >= minPeers (${AminoConstants.serverModeMinPeers}). Switching to server mode.');
+            _log.info(
+                '$logPrefix Auto mode: table size ($tableSize) >= minPeers (${AminoConstants.serverModeMinPeers}). Switching to server mode.');
             _mode = DHTMode.server;
             _setupProtocolHandlers();
             _log.info('$logPrefix Switched to server mode.');
@@ -307,7 +323,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
 
   /// Sets up protocol handlers for incoming requests
   void _setupProtocolHandlers() {
-    print('Setting up protocol handlers for ${AminoConstants.protocolID} directly on host.');
+    print(
+        'Setting up protocol handlers for ${AminoConstants.protocolID} directly on host.');
     // Changed from _host.network.setStreamHandler to _host.setStreamHandler
     // to match where MockHost.newStream looks for handlers.
     _host.setStreamHandler(AminoConstants.protocolID, _handleIncomingStream);
@@ -315,7 +332,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
 
   /// Handles an incoming stream
   // Reverted stream type to dynamic to match potential StreamHandler typedef, will cast internally.
-  Future<void> _handleIncomingStream(dynamic streamInput, PeerId remotePeer) async {
+  Future<void> _handleIncomingStream(
+      dynamic streamInput, PeerId remotePeer) async {
     // Cast to P2PStream<Uint8List> for type safety within the method.
     // This assumes the actual stream passed will conform to this.
     final P2PStream<Uint8List> stream = streamInput as P2PStream<Uint8List>;
@@ -327,7 +345,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
       final remoteAddr = conn.remoteMultiaddr;
       remotePeerAddrs = [remoteAddr];
     } catch (e) {
-      _log.fine('[${_host.id.toBase58().substring(0,6)}._handleIncomingStream] Could not extract remote address for ${remotePeer.toBase58().substring(0,6)}: $e');
+      _log.fine(
+          '[${_host.id.toBase58().substring(0, 6)}._handleIncomingStream] Could not extract remote address for ${remotePeer.toBase58().substring(0, 6)}: $e');
     }
 
     try {
@@ -340,7 +359,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
       } else if (rawMessageData is List<int>) {
         messageBytes = Uint8List.fromList(rawMessageData);
       } else {
-        _log.warning('[${_host.id.toBase58().substring(0,6)}._handleIncomingStream] Unexpected data type: ${rawMessageData.runtimeType}. Peer: $remotePeer');
+        _log.warning(
+            '[${_host.id.toBase58().substring(0, 6)}._handleIncomingStream] Unexpected data type: ${rawMessageData.runtimeType}. Peer: $remotePeer');
         await stream.reset();
         return;
       }
@@ -366,12 +386,16 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
 
       // Defer peerstore address storage to AFTER response is sent (non-blocking)
       if (remotePeerAddrs != null && remotePeerAddrs.isNotEmpty) {
-        _host.peerStore.addrBook.addAddrs(remotePeer, remotePeerAddrs, Duration(hours: 1)).catchError((e) {
-          _log.warning('[${_host.id.toBase58().substring(0,6)}._handleIncomingStream] Error storing addresses for ${remotePeer.toBase58().substring(0,6)}: $e');
+        _host.peerStore.addrBook
+            .addAddrs(remotePeer, remotePeerAddrs, Duration(hours: 1))
+            .catchError((e) {
+          _log.warning(
+              '[${_host.id.toBase58().substring(0, 6)}._handleIncomingStream] Error storing addresses for ${remotePeer.toBase58().substring(0, 6)}: $e');
         });
       }
     } catch (e) {
-      print('[IpfsDHT._handleIncomingStream] Error handling incoming stream from $remotePeer: $e');
+      print(
+          '[IpfsDHT._handleIncomingStream] Error handling incoming stream from $remotePeer: $e');
       await stream.reset();
     }
   }
@@ -407,7 +431,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     _log.fine('$logPrefix Removed protocol handlers.');
 
     // Dispose of all active QueryRunner instances
-    _log.info('$logPrefix Disposing ${_activeQueryRunners.length} active QueryRunner instances...');
+    _log.info(
+        '$logPrefix Disposing ${_activeQueryRunners.length} active QueryRunner instances...');
     final queryRunnerDisposals = <Future>[];
     for (final runner in _activeQueryRunners) {
       queryRunnerDisposals.add(runner.dispose());
@@ -450,20 +475,26 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   }
 
   /// Gets the closest peers to a target
-  /// 
+  ///
   /// This method first checks the local routing table, and if insufficient peers
   /// are found, performs network queries to discover additional peers.
-  Future<List<AddrInfo>> getClosestPeers(PeerId target, {bool networkQueryEnabled = true}) async {
-    final logPrefix = '[${_host.id.toBase58().substring(0, 6)}.getClosestPeers]';
+  Future<List<AddrInfo>> getClosestPeers(PeerId target,
+      {bool networkQueryEnabled = true}) async {
+    final logPrefix =
+        '[${_host.id.toBase58().substring(0, 6)}.getClosestPeers]';
     final targetShortId = target.toBase58().substring(0, 6);
-    print('$logPrefix *** DEBUG: Finding closest peers to $targetShortId (networkQuery: $networkQueryEnabled)');
+    print(
+        '$logPrefix *** DEBUG: Finding closest peers to $targetShortId (networkQuery: $networkQueryEnabled)');
     print('$logPrefix *** DEBUG: _options.resiliency = ${_options.resiliency}');
 
     // Phase 1: Get peers from local routing table
-    final localPeerIds = await _routingTable.nearestPeers(target.toBytes(), _options.resiliency);
-    print('$logPrefix *** DEBUG: Found ${localPeerIds.length} peers in local routing table');
+    final localPeerIds =
+        await _routingTable.nearestPeers(target.toBytes(), _options.resiliency);
+    print(
+        '$logPrefix *** DEBUG: Found ${localPeerIds.length} peers in local routing table');
     for (int i = 0; i < localPeerIds.length; i++) {
-      print('$logPrefix *** DEBUG: Local peer $i: ${localPeerIds[i].toBase58().substring(0,6)}');
+      print(
+          '$logPrefix *** DEBUG: Local peer $i: ${localPeerIds[i].toBase58().substring(0, 6)}');
     }
 
     // Convert PeerId objects to AddrInfo objects
@@ -471,22 +502,27 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     for (final peerId in localPeerIds) {
       // Get the peer's addresses from the peerstore
       final peerInfoFromStore = await _host.peerStore.getPeer(peerId);
-      localResult.add(AddrInfo(peerId, peerInfoFromStore?.addrs.toList() ?? []));
+      localResult
+          .add(AddrInfo(peerId, peerInfoFromStore?.addrs.toList() ?? []));
     }
 
-    print('$logPrefix *** DEBUG: Local result count: ${localResult.length}, resiliency: ${_options.resiliency}, networkQueryEnabled: $networkQueryEnabled');
+    print(
+        '$logPrefix *** DEBUG: Local result count: ${localResult.length}, resiliency: ${_options.resiliency}, networkQueryEnabled: $networkQueryEnabled');
 
     // If we have sufficient peers from local routing table, return them
     if (localResult.length >= _options.resiliency || !networkQueryEnabled) {
-      print('$logPrefix *** DEBUG: EARLY RETURN - Returning ${localResult.length} peers from local routing table (sufficient or network query disabled)');
+      print(
+          '$logPrefix *** DEBUG: EARLY RETURN - Returning ${localResult.length} peers from local routing table (sufficient or network query disabled)');
       return localResult;
     }
 
     // Phase 2: Network query for additional peers if local results are insufficient
-    print('$logPrefix *** DEBUG: NETWORK QUERY TRIGGERED - Local routing table has only ${localResult.length} peers (< ${_options.resiliency}). Performing network query...');
+    print(
+        '$logPrefix *** DEBUG: NETWORK QUERY TRIGGERED - Local routing table has only ${localResult.length} peers (< ${_options.resiliency}). Performing network query...');
 
     if (!_started) {
-      _log.fine('$logPrefix DHT not started, calling start() before network query.');
+      _log.fine(
+          '$logPrefix DHT not started, calling start() before network query.');
       await start();
     }
 
@@ -494,60 +530,65 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
       // Use existing runLookupWithFollowup infrastructure to query the network
       // We'll collect both peer IDs and their addresses from network responses
       final networkPeersWithAddrs = <PeerId, AddrInfo>{};
-      
+
       final networkResult = await runLookupWithFollowup(
         target: target.toBytes(),
         queryFn: (peer) async {
-          final queryFnLogPrefix = '$logPrefix [networkQuery.queryFn for ${peer.toBase58().substring(0,6)}]';
-          _log.fine('$queryFnLogPrefix Sending FIND_NODE for target $targetShortId');
-          
+          final queryFnLogPrefix =
+              '$logPrefix [networkQuery.queryFn for ${peer.toBase58().substring(0, 6)}]';
+          _log.fine(
+              '$queryFnLogPrefix Sending FIND_NODE for target $targetShortId');
+
           final message = Message(
             type: MessageType.findNode,
             key: target.toBytes(),
           );
-          
+
           final response = await _sendMessage(peer, message);
-          _log.fine('$queryFnLogPrefix Got FIND_NODE response with ${response.closerPeers.length} closer peers');
-          
+          _log.fine(
+              '$queryFnLogPrefix Got FIND_NODE response with ${response.closerPeers.length} closer peers');
+
           // Convert response peers to AddrInfo objects AND store them for later use
           final addrInfoList = response.closerPeers.map((p) {
             final peerId = PeerId.fromBytes(p.id);
-            final addrs = p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList();
+            final addrs =
+                p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList();
             final addrInfo = AddrInfo(peerId, addrs);
-            
+
             // Store the peer with its addresses from the network response
             // This preserves the addresses that came directly from the bootstrap server
             networkPeersWithAddrs[peerId] = addrInfo;
-            _log.fine('$queryFnLogPrefix Stored peer ${peerId.toBase58().substring(0,6)} with ${addrs.length} addresses from network response');
-            
+            _log.fine(
+                '$queryFnLogPrefix Stored peer ${peerId.toBase58().substring(0, 6)} with ${addrs.length} addresses from network response');
+
             return addrInfo;
           }).toList();
-          
+
           return addrInfoList;
         },
         stopFn: (peerset) {
           // Stop when we've queried enough peers or found sufficient diverse peers
-          final queriedCount = peerset.getClosestInStates([PeerState.queried]).length;
-          final totalPeersFound = peerset.getClosestInStates([
-            PeerState.queried, 
-            PeerState.heard, 
-            PeerState.waiting
-          ]).length;
-          
-          final stop = queriedCount >= _options.resiliency || totalPeersFound >= (_options.resiliency * 2);
-          _log.finer('$logPrefix [networkQuery.stopFn] Queried: $queriedCount, Total found: $totalPeersFound, Resiliency: ${_options.resiliency}. Stop: $stop');
+          final queriedCount =
+              peerset.getClosestInStates([PeerState.queried]).length;
+          final totalPeersFound = peerset.getClosestInStates(
+              [PeerState.queried, PeerState.heard, PeerState.waiting]).length;
+
+          final stop = queriedCount >= _options.resiliency ||
+              totalPeersFound >= (_options.resiliency * 2);
+          _log.finer(
+              '$logPrefix [networkQuery.stopFn] Queried: $queriedCount, Total found: $totalPeersFound, Resiliency: ${_options.resiliency}. Stop: $stop');
           return stop;
         },
       );
 
       // Combine local and network results, removing duplicates
       final combinedPeers = <PeerId, AddrInfo>{};
-      
+
       // Add local peers first (they're already connected)
       for (final localPeer in localResult) {
         combinedPeers[localPeer.id] = localPeer;
       }
-      
+
       // Add network-discovered peers using the addresses we preserved from network responses
       for (final networkPeerId in networkResult.peers) {
         if (!combinedPeers.containsKey(networkPeerId)) {
@@ -556,35 +597,39 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
           final networkPeerWithAddrs = networkPeersWithAddrs[networkPeerId];
           if (networkPeerWithAddrs != null) {
             combinedPeers[networkPeerId] = networkPeerWithAddrs;
-            _log.fine('$logPrefix Using preserved addresses for network peer ${networkPeerId.toBase58().substring(0,6)}: ${networkPeerWithAddrs.addrs.length} addresses');
+            _log.fine(
+                '$logPrefix Using preserved addresses for network peer ${networkPeerId.toBase58().substring(0, 6)}: ${networkPeerWithAddrs.addrs.length} addresses');
           } else {
             // Fallback to peerstore if somehow not found in our preserved map
-            final peerInfoFromStore = await _host.peerStore.getPeer(networkPeerId);
+            final peerInfoFromStore =
+                await _host.peerStore.getPeer(networkPeerId);
             combinedPeers[networkPeerId] = AddrInfo(
-              networkPeerId, 
-              peerInfoFromStore?.addrs.toList() ?? []
-            );
-            _log.warning('$logPrefix Fallback to peerstore for network peer ${networkPeerId.toBase58().substring(0,6)} (${peerInfoFromStore?.addrs.length ?? 0} addresses)');
+                networkPeerId, peerInfoFromStore?.addrs.toList() ?? []);
+            _log.warning(
+                '$logPrefix Fallback to peerstore for network peer ${networkPeerId.toBase58().substring(0, 6)} (${peerInfoFromStore?.addrs.length ?? 0} addresses)');
           }
         }
       }
 
       final finalResult = combinedPeers.values.toList();
-      _log.info('$logPrefix Network query completed. Combined result: ${finalResult.length} peers (${localResult.length} local + ${finalResult.length - localResult.length} network)');
-      
+      _log.info(
+          '$logPrefix Network query completed. Combined result: ${finalResult.length} peers (${localResult.length} local + ${finalResult.length - localResult.length} network)');
+
       // Log the peer IDs for debugging
       for (int i = 0; i < finalResult.length; i++) {
         final peer = finalResult[i];
-        final source = localResult.any((p) => p.id == peer.id) ? 'local' : 'network';
-        _log.fine('$logPrefix Result peer $i: ${peer.id.toBase58().substring(0,6)} ($source, ${peer.addrs.length} addrs)');
+        final source =
+            localResult.any((p) => p.id == peer.id) ? 'local' : 'network';
+        _log.fine(
+            '$logPrefix Result peer $i: ${peer.id.toBase58().substring(0, 6)} ($source, ${peer.addrs.length} addrs)');
       }
-      
+
       return finalResult;
-      
     } catch (e, s) {
       _log.warning('$logPrefix Network query failed: $e', e, s);
       // Fall back to local results even if insufficient
-      _log.info('$logPrefix Falling back to ${localResult.length} local peers due to network query failure');
+      _log.info(
+          '$logPrefix Falling back to ${localResult.length} local peers due to network query failure');
       return localResult;
     }
   }
@@ -595,9 +640,11 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     final keyString = base64Encode(key);
     final record = _datastore[keyString];
     if (record != null) {
-      log.fine('[${_host.id.toBase58().substring(0,6)}] Found record for key "$keyString". Value: "${utf8.decode(record.value, allowMalformed: true)}" (Length: ${record.value.length})');
+      log.fine(
+          '[${_host.id.toBase58().substring(0, 6)}] Found record for key "$keyString". Value: "${utf8.decode(record.value, allowMalformed: true)}" (Length: ${record.value.length})');
     } else {
-      log.fine('[${_host.id.toBase58().substring(0,6)}] No record found for key "$keyString".');
+      log.fine(
+          '[${_host.id.toBase58().substring(0, 6)}] No record found for key "$keyString".');
     }
     return record;
   }
@@ -613,7 +660,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   Future<void> putRecordToDatastore(Record record) async {
     final Logger log = Logger('IpfsDHT.putRecordToDatastore');
     final keyString = base64Encode(record.key);
-    log.fine('[${_host.id.toBase58().substring(0,6)}] Storing record for key "$keyString". Value: "${utf8.decode(record.value, allowMalformed: true)}" (Length: ${record.value.length}), Author: ${PeerId.fromBytes(record.author).toBase58()}');
+    log.fine(
+        '[${_host.id.toBase58().substring(0, 6)}] Storing record for key "$keyString". Value: "${utf8.decode(record.value, allowMalformed: true)}" (Length: ${record.value.length}), Author: ${PeerId.fromBytes(record.author).toBase58()}');
     _datastore[keyString] = record;
   }
 
@@ -632,24 +680,27 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   /// Dials a peer
   Future<void> dialPeer(PeerId peer) async {
     final Logger dialLogger = Logger('IpfsDHT.dialPeer');
-    dialLogger.info('[${_host.id.toBase58().substring(0,6)}] Attempting to dial peer ${peer.toBase58().substring(0,6)}');
+    dialLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] Attempting to dial peer ${peer.toBase58().substring(0, 6)}');
 
     // If dialing self, we can assume the host is already "connected" to itself.
     // Skip the explicit _host.connect() call to avoid issues with repeated self-connections.
     if (peer == _host.id) {
-      dialLogger.info('[${_host.id.toBase58().substring( 0, 6)}] Self-dial detected for ${peer.toBase58().substring( 0, 6)}. Skipping _host.connect().');
+      dialLogger.info(
+          '[${_host.id.toBase58().substring(0, 6)}] Self-dial detected for ${peer.toBase58().substring(0, 6)}. Skipping _host.connect().');
       return;
     }
 
     // Get AddrInfo for the peer from the peerstore
-    final peerInfo = await _host.peerStore.getPeer(peer); 
+    final peerInfo = await _host.peerStore.getPeer(peer);
     if (peerInfo == null || peerInfo.addrs.isEmpty) {
-      dialLogger.warning('[${_host.id.toBase58().substring(0,6)}] No addresses found for peer ${peer.toBase58().substring(0,6)} in peerstore. Cannot dial.');
-      return; 
+      dialLogger.warning(
+          '[${_host.id.toBase58().substring(0, 6)}] No addresses found for peer ${peer.toBase58().substring(0, 6)} in peerstore. Cannot dial.');
+      return;
     }
 
     List<MultiAddr> addrsToUse = peerInfo.addrs.toList();
-    
+
     // Transform 0.0.0.0 addresses to 127.0.0.1 for connection attempts,
     // as 0.0.0.0 is a listen address, not a connectable target from another local process.
     final List<MultiAddr> effectiveAddrs = [];
@@ -657,23 +708,31 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
       String addrStr = addr.toString();
       if (addrStr.startsWith('/ip4/0.0.0.0/')) {
         try {
-          effectiveAddrs.add(MultiAddr(addrStr.replaceFirst('/ip4/0.0.0.0/', '/ip4/127.0.0.1/')));
+          effectiveAddrs.add(MultiAddr(
+              addrStr.replaceFirst('/ip4/0.0.0.0/', '/ip4/127.0.0.1/')));
         } catch (e) {
-          dialLogger.warning("Failed to transform 0.0.0.0 address '$addrStr' to 127.0.0.1 for connect: $e");
+          dialLogger.warning(
+              "Failed to transform 0.0.0.0 address '$addrStr' to 127.0.0.1 for connect: $e");
           effectiveAddrs.add(addr); // Fallback to original on error
         }
       } else {
         effectiveAddrs.add(addr);
       }
     }
-    dialLogger.fine('[${_host.id.toBase58().substring(0,6)}] Original addrs for ${peer.toBase58().substring(0,6)}: ${addrsToUse.map((a) => a.toString()).join(", ")}. Effective addrs for connect: ${effectiveAddrs.map((a) => a.toString()).join(", ")}.');
+    dialLogger.fine(
+        '[${_host.id.toBase58().substring(0, 6)}] Original addrs for ${peer.toBase58().substring(0, 6)}: ${addrsToUse.map((a) => a.toString()).join(", ")}. Effective addrs for connect: ${effectiveAddrs.map((a) => a.toString()).join(", ")}.');
 
     try {
-      final addrInfoToConnect = AddrInfo(peer, effectiveAddrs); // Use transformed addresses
+      final addrInfoToConnect =
+          AddrInfo(peer, effectiveAddrs); // Use transformed addresses
       await _host.connect(addrInfoToConnect);
-      dialLogger.info('[${_host.id.toBase58().substring(0,6)}] Successfully connected to peer ${peer.toBase58().substring(0,6)}.');
+      dialLogger.info(
+          '[${_host.id.toBase58().substring(0, 6)}] Successfully connected to peer ${peer.toBase58().substring(0, 6)}.');
     } catch (e, s) {
-      dialLogger.severe('[${_host.id.toBase58().substring(0,6)}] Error connecting to peer ${peer.toBase58().substring(0,6)}: $e', e, s);
+      dialLogger.severe(
+          '[${_host.id.toBase58().substring(0, 6)}] Error connecting to peer ${peer.toBase58().substring(0, 6)}: $e',
+          e,
+          s);
       rethrow; // Rethrow the error so the caller (e.g., _sendMessage) can handle it.
     }
   }
@@ -684,65 +743,82 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     final List<AddrInfo> result = [];
 
     // 1. Try peers from our routing table first
-    final rtDhtPeerInfos = await _routingTable.listPeers(); // These are DhtPeerInfo
+    final rtDhtPeerInfos =
+        await _routingTable.listPeers(); // These are DhtPeerInfo
     for (final rtDhtPeerInfo in rtDhtPeerInfos) {
       // Get PeerInfo (which contains addrs) from the peerstore
-      final storedPeerInfo = await _host.peerStore.getPeer(rtDhtPeerInfo.id); // rtDhtPeerInfo.id is correct (PeerId)
+      final storedPeerInfo = await _host.peerStore
+          .getPeer(rtDhtPeerInfo.id); // rtDhtPeerInfo.id is correct (PeerId)
       if (storedPeerInfo != null && storedPeerInfo.addrs.isNotEmpty) {
         // Only add if we have addresses for them
         // PeerInfo from peerstore should have 'peerId', not 'id'
-        result.add(AddrInfo(storedPeerInfo.peerId, storedPeerInfo.addrs.toList()));
+        result.add(
+            AddrInfo(storedPeerInfo.peerId, storedPeerInfo.addrs.toList()));
       }
     }
-    bootstrapLogger.info('[${_host.id.toBase58().substring(0,6)}] Initially got ${result.length} peers from routing table with addresses.');
+    bootstrapLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] Initially got ${result.length} peers from routing table with addresses.');
 
     // 2. If routing table yielded no usable peers (e.g., empty or peers have no known addrs),
     //    use configured bootstrap peers from DHTOptions.
-    if (result.isEmpty && _options.bootstrapPeers != null && _options.bootstrapPeers!.isNotEmpty) {
-      bootstrapLogger.info('[${_host.id.toBase58().substring(0,6)}] Routing table yielded no usable peers. Using configured bootstrapPeers from DHTOptions.');
+    if (result.isEmpty &&
+        _options.bootstrapPeers != null &&
+        _options.bootstrapPeers!.isNotEmpty) {
+      bootstrapLogger.info(
+          '[${_host.id.toBase58().substring(0, 6)}] Routing table yielded no usable peers. Using configured bootstrapPeers from DHTOptions.');
       for (final ma in _options.bootstrapPeers!) {
         try {
           final p2pComponent = ma.valueForProtocol(Protocols.p2p.name);
           if (p2pComponent == null) {
-            bootstrapLogger.warning('[${_host.id.toBase58().substring(0,6)}] Configured bootstrap peer $ma is missing /p2p component. Skipping.');
+            bootstrapLogger.warning(
+                '[${_host.id.toBase58().substring(0, 6)}] Configured bootstrap peer $ma is missing /p2p component. Skipping.');
             continue;
           }
           final peerId = PeerId.fromString(p2pComponent);
 
           // Skip adding self if it's in the bootstrap list
           if (peerId == _host.id) {
-            bootstrapLogger.finer('[${_host.id.toBase58().substring(0,6)}] Skipping self from configured bootstrap peers: $peerId');
+            bootstrapLogger.finer(
+                '[${_host.id.toBase58().substring(0, 6)}] Skipping self from configured bootstrap peers: $peerId');
             continue;
           }
-          
+
           final addrOnly = ma.decapsulate(Protocols.p2p.name);
           if (addrOnly != null && addrOnly.toString().isNotEmpty) {
             result.add(AddrInfo(peerId, [addrOnly]));
           } else {
-             bootstrapLogger.warning('[${_host.id.toBase58().substring(0,6)}] Configured bootstrap multiaddress $ma has no connectable address part after decapsulating /p2p. Skipping.');
+            bootstrapLogger.warning(
+                '[${_host.id.toBase58().substring(0, 6)}] Configured bootstrap multiaddress $ma has no connectable address part after decapsulating /p2p. Skipping.');
           }
         } catch (e, s) {
-          bootstrapLogger.warning('[${_host.id.toBase58().substring(0,6)}] Error processing configured bootstrap multiaddress $ma: $e\n$s. Skipping.');
+          bootstrapLogger.warning(
+              '[${_host.id.toBase58().substring(0, 6)}] Error processing configured bootstrap multiaddress $ma: $e\n$s. Skipping.');
         }
       }
-      bootstrapLogger.info('[${_host.id.toBase58().substring(0,6)}] After processing DHTOptions.bootstrapPeers, result has ${result.length} peers.');
+      bootstrapLogger.info(
+          '[${_host.id.toBase58().substring(0, 6)}] After processing DHTOptions.bootstrapPeers, result has ${result.length} peers.');
     }
-    
+
     // Deduplicate, prioritizing entries that might have come from routing table (though current logic adds them first)
     final finalPeers = <PeerId, AddrInfo>{};
     for (var ai in result) {
-        finalPeers.putIfAbsent(ai.id, () => ai);
+      finalPeers.putIfAbsent(ai.id, () => ai);
     }
 
-    bootstrapLogger.info('[${_host.id.toBase58().substring(0,6)}] Raw DhtPeerInfo from routingTable.listPeers(): ${rtDhtPeerInfos.map((p) => p.id.toBase58().substring(0,6)).toList()} (Count: ${rtDhtPeerInfos.length})');
-    bootstrapLogger.info('[${_host.id.toBase58().substring(0,6)}] Returning ${finalPeers.values.length} unique bootstrap peers for lookup: ${finalPeers.values.map((ai) => '${ai.id.toBase58().substring(0,6)}(${ai.addrs.length} addrs)').toList()}');
+    bootstrapLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] Raw DhtPeerInfo from routingTable.listPeers(): ${rtDhtPeerInfos.map((p) => p.id.toBase58().substring(0, 6)).toList()} (Count: ${rtDhtPeerInfos.length})');
+    bootstrapLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] Returning ${finalPeers.values.length} unique bootstrap peers for lookup: ${finalPeers.values.map((ai) => '${ai.id.toBase58().substring(0, 6)}(${ai.addrs.length} addrs)').toList()}');
     return finalPeers.values.toList();
   }
 
   @override
-  Future<void> bootstrap({bool quickConnectOnly = false, Duration? periodicRefreshInterval}) async {
+  Future<void> bootstrap(
+      {bool quickConnectOnly = false,
+      Duration? periodicRefreshInterval}) async {
     final logPrefix = '[${_host.id.toBase58().substring(0, 6)}.bootstrap]';
-    _log.info('$logPrefix Starting bootstrap process (quickConnectOnly: $quickConnectOnly, periodicRefresh: $periodicRefreshInterval).');
+    _log.info(
+        '$logPrefix Starting bootstrap process (quickConnectOnly: $quickConnectOnly, periodicRefresh: $periodicRefreshInterval).');
 
     if (_closed) {
       _log.warning('$logPrefix Attempted to bootstrap a closed DHT.');
@@ -757,17 +833,22 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     int explicitPeersToQuickConnect = 2; // Max peers for the "quick" part
     int connectedExplicitly = 0;
 
-    if (_options.bootstrapPeers != null && _options.bootstrapPeers!.isNotEmpty) {
-      _log.info('$logPrefix Processing ${_options.bootstrapPeers!.length} explicit bootstrap peers for initial connection phase.');
+    if (_options.bootstrapPeers != null &&
+        _options.bootstrapPeers!.isNotEmpty) {
+      _log.info(
+          '$logPrefix Processing ${_options.bootstrapPeers!.length} explicit bootstrap peers for initial connection phase.');
       for (final ma in _options.bootstrapPeers!) {
-        if (connectedExplicitly >= explicitPeersToQuickConnect && quickConnectOnly) {
-            _log.fine('$logPrefix Reached quick connect limit ($explicitPeersToQuickConnect). Further explicit peers will be handled by background task if any.');
-            break;
+        if (connectedExplicitly >= explicitPeersToQuickConnect &&
+            quickConnectOnly) {
+          _log.fine(
+              '$logPrefix Reached quick connect limit ($explicitPeersToQuickConnect). Further explicit peers will be handled by background task if any.');
+          break;
         }
         try {
           final p2pComponent = ma.valueForProtocol(Protocols.p2p.name);
           if (p2pComponent == null) {
-            _log.warning('$logPrefix Configured bootstrap peer $ma is missing /p2p component. Skipping.');
+            _log.warning(
+                '$logPrefix Configured bootstrap peer $ma is missing /p2p component. Skipping.');
             continue;
           }
           final peerId = PeerId.fromString(p2pComponent);
@@ -775,80 +856,103 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
 
           if (connectAddr != null && connectAddr.toString().isNotEmpty) {
             final addrInfo = AddrInfo(peerId, [connectAddr]);
-            final peerShortId = addrInfo.id.toBase58().substring(0,6);
-            _log.info('$logPrefix Attempting to connect to explicit bootstrap peer: $peerShortId via ${addrInfo.addrs}');
-            _host.peerStore.addrBook.addAddrs(addrInfo.id, addrInfo.addrs, Duration(hours: 24)); // Add to peerstore
+            final peerShortId = addrInfo.id.toBase58().substring(0, 6);
+            _log.info(
+                '$logPrefix Attempting to connect to explicit bootstrap peer: $peerShortId via ${addrInfo.addrs}');
+            _host.peerStore.addrBook.addAddrs(addrInfo.id, addrInfo.addrs,
+                Duration(hours: 24)); // Add to peerstore
             _log.finer('$logPrefix Before _host.connect for $peerShortId');
             await _host.connect(addrInfo); // Connect
-            _log.finer('$logPrefix After _host.connect for $peerShortId, before tryAddPeer.');
-            bool addedToRt = await _routingTable.tryAddPeer(addrInfo.id, queryPeer: true); // Add to routing table
-            _log.finer('$logPrefix After tryAddPeer for $peerShortId. Result addedToRt: $addedToRt.');
+            _log.finer(
+                '$logPrefix After _host.connect for $peerShortId, before tryAddPeer.');
+            bool addedToRt = await _routingTable.tryAddPeer(addrInfo.id,
+                queryPeer: true); // Add to routing table
+            _log.finer(
+                '$logPrefix After tryAddPeer for $peerShortId. Result addedToRt: $addedToRt.');
             final currentSize = await _routingTable.size();
-            _log.finer('$logPrefix After _routingTable.size(). Current RT Size: $currentSize.');
-            _log.info('$logPrefix Explicit bootstrap peer $peerShortId connected and processed. Added to RT: $addedToRt. RT Size: $currentSize');
+            _log.finer(
+                '$logPrefix After _routingTable.size(). Current RT Size: $currentSize.');
+            _log.info(
+                '$logPrefix Explicit bootstrap peer $peerShortId connected and processed. Added to RT: $addedToRt. RT Size: $currentSize');
             connectedExplicitly++;
           } else {
-            _log.warning('$logPrefix Configured bootstrap multiaddress $ma has no connectable address part. Skipping.');
+            _log.warning(
+                '$logPrefix Configured bootstrap multiaddress $ma has no connectable address part. Skipping.');
           }
         } catch (e, s) {
-          _log.warning('$logPrefix Error processing explicit bootstrap multiaddress $ma: $e\n$s. Skipping.');
+          _log.warning(
+              '$logPrefix Error processing explicit bootstrap multiaddress $ma: $e\n$s. Skipping.');
         }
       }
     } else {
-      _log.info('$logPrefix No explicit bootstrap peers configured in _options.bootstrapPeers for initial connection.');
+      _log.info(
+          '$logPrefix No explicit bootstrap peers configured in _options.bootstrapPeers for initial connection.');
     }
-    _log.info('$logPrefix Initial explicit peer connection phase completed. Connected to $connectedExplicitly peers.');
+    _log.info(
+        '$logPrefix Initial explicit peer connection phase completed. Connected to $connectedExplicitly peers.');
 
     // --- Phase 2: Deeper population and periodic refresh ---
     if (quickConnectOnly) {
-      _log.info('$logPrefix Quick bootstrap requested. Initiating background tasks for fuller population and returning.');
+      _log.info(
+          '$logPrefix Quick bootstrap requested. Initiating background tasks for fuller population and returning.');
       _initiateBackgroundTasks(periodicRefreshInterval);
       return;
     }
 
     // If not quickConnectOnly, perform the deeper population now and await it.
-    _log.info('$logPrefix Full bootstrap requested. Performing deeper routing table population now.');
+    _log.info(
+        '$logPrefix Full bootstrap requested. Performing deeper routing table population now.');
     await _populateRoutingTable(); // Await the first full population
-    _initiateBackgroundTasks(periodicRefreshInterval); // Then set up background tasks (mainly for periodic refresh if interval provided)
-    _log.info('$logPrefix Full bootstrap process (including initial deep population) finished.');
+    _initiateBackgroundTasks(
+        periodicRefreshInterval); // Then set up background tasks (mainly for periodic refresh if interval provided)
+    _log.info(
+        '$logPrefix Full bootstrap process (including initial deep population) finished.');
   }
 
   void _initiateBackgroundTasks(Duration? periodicRefreshInterval) {
-    final logPrefix = '[${_host.id.toBase58().substring(0, 6)}.backgroundTasks]';
+    final logPrefix =
+        '[${_host.id.toBase58().substring(0, 6)}.backgroundTasks]';
     if (_closed) {
-        _log.info('$logPrefix DHT is closed, not initiating background tasks.');
-        return;
+      _log.info('$logPrefix DHT is closed, not initiating background tasks.');
+      return;
     }
 
     if (!_backgroundTasksInitiated) {
       _backgroundTasksInitiated = true; // Set flag early to prevent re-entry
-      _log.info('$logPrefix First time initiation: Starting one-off background routing table population.');
+      _log.info(
+          '$logPrefix First time initiation: Starting one-off background routing table population.');
       _populateRoutingTable().catchError((e, s) {
-        _log.severe('$logPrefix Error during initial background routing table population: $e\n$s');
+        _log.severe(
+            '$logPrefix Error during initial background routing table population: $e\n$s');
         // Potentially reset _backgroundTasksInitiated = false; if you want it to be re-triggerable on error
         // For now, keep it true to avoid repeated attempts on persistent errors without a cool-down.
       }).whenComplete(() {
-        _log.info('$logPrefix Initial background population task completed (or errored).');
+        _log.info(
+            '$logPrefix Initial background population task completed (or errored).');
       });
     } else {
-      _log.info('$logPrefix Background population task was already initiated. Skipping one-off run.');
+      _log.info(
+          '$logPrefix Background population task was already initiated. Skipping one-off run.');
     }
 
     if (periodicRefreshInterval != null) {
       _backgroundRefreshCompleter?.complete(); // Cancel any existing refresh
       _backgroundRefreshCompleter = Completer<void>();
-      _log.info('$logPrefix Setting up periodic background refresh every $periodicRefreshInterval.');
+      _log.info(
+          '$logPrefix Setting up periodic background refresh every $periodicRefreshInterval.');
       _startPeriodicRefresh(periodicRefreshInterval);
     } else {
-       _log.info('$logPrefix No periodicRefreshInterval provided, periodic refresh will not be scheduled.');
+      _log.info(
+          '$logPrefix No periodicRefreshInterval provided, periodic refresh will not be scheduled.');
     }
   }
 
   Future<void> _populateRoutingTable() async {
-    final logPrefix = '[${_host.id.toBase58().substring(0, 6)}.populateRoutingTable]';
+    final logPrefix =
+        '[${_host.id.toBase58().substring(0, 6)}.populateRoutingTable]';
     if (_closed) {
-        _log.info('$logPrefix DHT is closed, aborting population task.');
-        return;
+      _log.info('$logPrefix DHT is closed, aborting population task.');
+      return;
     }
     _log.info('$logPrefix Starting deeper routing table population task.');
 
@@ -856,81 +960,103 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     // These are peers already in our routing table. Connecting to them again helps ensure liveness
     // and refreshes their status.
     try {
-        final peersFromTable = await getBootstrapPeers(); // This gets AddrInfo from RT
-        _log.info('$logPrefix Processing ${peersFromTable.length} peers already in routing table.');
-        for (final peerAddrInfo in peersFromTable) {
-            if (_closed) break; // Check if DHT closed during long loop
-            final peerShortId = peerAddrInfo.id.toBase58().substring(0,6);
-            
-            // Skip self-dial attempts - prevent trying to connect to our own peer ID
-            if (peerAddrInfo.id == _host.id) {
-                _log.fine('$logPrefix Skipping self-dial attempt for local peer $peerShortId in routing table population.');
-                continue;
-            }
-            
-            try {
-                _log.finer('$logPrefix Connecting to/refreshing peer from table: $peerShortId');
-                await _host.connect(peerAddrInfo);
-                // queryPeer: false because we are just refreshing, not expecting them to be new for query purposes.
-                bool added = await _routingTable.tryAddPeer(peerAddrInfo.id, queryPeer: false);
-                _log.finer('$logPrefix Refreshed peer from table $peerShortId. Added to RT (likely updated): $added. RT size: ${await _routingTable.size()}');
-            } catch (e, s) {
-                _log.warning('$logPrefix Error refreshing peer from table $peerShortId: $e\n$s');
-            }
+      final peersFromTable =
+          await getBootstrapPeers(); // This gets AddrInfo from RT
+      _log.info(
+          '$logPrefix Processing ${peersFromTable.length} peers already in routing table.');
+      for (final peerAddrInfo in peersFromTable) {
+        if (_closed) break; // Check if DHT closed during long loop
+        final peerShortId = peerAddrInfo.id.toBase58().substring(0, 6);
+
+        // Skip self-dial attempts - prevent trying to connect to our own peer ID
+        if (peerAddrInfo.id == _host.id) {
+          _log.fine(
+              '$logPrefix Skipping self-dial attempt for local peer $peerShortId in routing table population.');
+          continue;
         }
-    } catch (e,s) {
-        _log.severe('$logPrefix Error in _populateRoutingTable while processing existing RT peers: $e\n$s');
+
+        try {
+          _log.finer(
+              '$logPrefix Connecting to/refreshing peer from table: $peerShortId');
+          await _host.connect(peerAddrInfo);
+          // queryPeer: false because we are just refreshing, not expecting them to be new for query purposes.
+          bool added =
+              await _routingTable.tryAddPeer(peerAddrInfo.id, queryPeer: false);
+          _log.finer(
+              '$logPrefix Refreshed peer from table $peerShortId. Added to RT (likely updated): $added. RT size: ${await _routingTable.size()}');
+        } catch (e, s) {
+          _log.warning(
+              '$logPrefix Error refreshing peer from table $peerShortId: $e\n$s');
+        }
+      }
+    } catch (e, s) {
+      _log.severe(
+          '$logPrefix Error in _populateRoutingTable while processing existing RT peers: $e\n$s');
     }
 
-
     if (_closed) {
-        _log.info('$logPrefix DHT closed, aborting before random lookup.');
-        return;
+      _log.info('$logPrefix DHT closed, aborting before random lookup.');
+      return;
     }
 
     // Part 2: Perform a random key lookup to discover new peers
     final currentTableSize = await _routingTable.size();
-    _log.info('$logPrefix Current routing table size before random lookup: $currentTableSize.');
+    _log.info(
+        '$logPrefix Current routing table size before random lookup: $currentTableSize.');
     if (currentTableSize > 0) {
       final randomKey = Uint8List.fromList(
         List.generate(32, (_) => math.Random().nextInt(256)),
       );
-      _log.info('$logPrefix Performing random key lookup for key: ${base64Encode(randomKey).substring(0,10)}... to populate routing table.');
+      _log.info(
+          '$logPrefix Performing random key lookup for key: ${base64Encode(randomKey).substring(0, 10)}... to populate routing table.');
 
       try {
         await runLookupWithFollowup(
           target: randomKey,
           queryFn: (peer) async {
-            final queryFnLogPrefix = '$logPrefix [randomLookup.queryFn for ${peer.toBase58().substring(0,6)}]';
+            final queryFnLogPrefix =
+                '$logPrefix [randomLookup.queryFn for ${peer.toBase58().substring(0, 6)}]';
             _log.fine('$queryFnLogPrefix Sending FIND_NODE for random key.');
             final message = Message(
               type: MessageType.findNode,
               key: randomKey,
             );
-            final response = await _sendMessage(peer, message); // _sendMessage has its own logging
-            _log.fine('$queryFnLogPrefix Got FIND_NODE response. CloserPeers: ${response.closerPeers.length}');
-            
+            final response = await _sendMessage(
+                peer, message); // _sendMessage has its own logging
+            _log.fine(
+                '$queryFnLogPrefix Got FIND_NODE response. CloserPeers: ${response.closerPeers.length}');
+
             // Try adding the queried peer to RT; queryPeer:false as its liveness is confirmed by response.
             bool added = await _routingTable.tryAddPeer(peer, queryPeer: false);
-            _log.finer('$queryFnLogPrefix Tried adding peer ${peer.toBase58().substring(0,6)} to RT (queryPeer:false). Success: $added. Current RT size: ${await _routingTable.size()}');
+            _log.finer(
+                '$queryFnLogPrefix Tried adding peer ${peer.toBase58().substring(0, 6)} to RT (queryPeer:false). Success: $added. Current RT size: ${await _routingTable.size()}');
 
-            return response.closerPeers.map((p) => AddrInfo(
-              PeerId.fromBytes(p.id),
-              p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-            )).toList();
+            return response.closerPeers
+                .map((p) => AddrInfo(
+                      PeerId.fromBytes(p.id),
+                      p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                    ))
+                .toList();
           },
           stopFn: (peerset) {
-            final stop = peerset.getClosestInStates([PeerState.queried]).length >= _options.resiliency;
-            _log.finer('$logPrefix [randomLookup.stopFn] Queried peers: ${peerset.getClosestInStates([PeerState.queried]).length}, Resiliency: ${_options.resiliency}. Stop: $stop');
+            final stop =
+                peerset.getClosestInStates([PeerState.queried]).length >=
+                    _options.resiliency;
+            _log.finer(
+                '$logPrefix [randomLookup.stopFn] Queried peers: ${peerset.getClosestInStates([
+                  PeerState.queried
+                ]).length}, Resiliency: ${_options.resiliency}. Stop: $stop');
             return stop;
           },
         );
-        _log.info('$logPrefix Random key lookup completed. Final RT Size: ${await _routingTable.size()}');
-      } catch (e,s) {
+        _log.info(
+            '$logPrefix Random key lookup completed. Final RT Size: ${await _routingTable.size()}');
+      } catch (e, s) {
         _log.severe('$logPrefix Error during random key lookup: $e\n$s');
       }
     } else {
-      _log.info('$logPrefix No bootstrap peers found or routing table empty. Skipping random key lookup.');
+      _log.info(
+          '$logPrefix No bootstrap peers found or routing table empty. Skipping random key lookup.');
     }
     _log.info('$logPrefix Deeper routing table population task finished.');
   }
@@ -938,14 +1064,15 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   /// Starts periodic refresh using Future.delayed instead of Timer.periodic.
   /// This prevents unhandled exceptions that can occur with Timer callbacks.
   void _startPeriodicRefresh(Duration interval) async {
-    final logPrefix = '[${_host.id.toBase58().substring(0, 6)}.periodicRefresh]';
+    final logPrefix =
+        '[${_host.id.toBase58().substring(0, 6)}.periodicRefresh]';
     try {
       while (!_closed && _started) {
         await Future.any([
           Future.delayed(interval),
           _backgroundRefreshCompleter!.future,
         ]);
-        
+
         if (_closed || !_started) {
           _log.info('$logPrefix DHT closed, stopping periodic refresh.');
           break;
@@ -955,7 +1082,10 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
           _log.info('$logPrefix Periodic background refresh triggered.');
           await _populateRoutingTable();
         } catch (e, s) {
-          _log.severe('$logPrefix Error during periodic background routing table population: $e', e, s);
+          _log.severe(
+              '$logPrefix Error during periodic background routing table population: $e',
+              e,
+              s);
         }
       }
     } catch (e, s) {
@@ -966,7 +1096,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   @override
   Future<void> provide(CID cid, bool announce) async {
     final logPrefix = '[${_host.id.toBase58().substring(0, 6)}.provide]';
-    _log.info('$logPrefix Called for CID: ${cid.toString()}, announce: $announce');
+    _log.info(
+        '$logPrefix Called for CID: ${cid.toString()}, announce: $announce');
 
     if (!_started) {
       _log.fine('$logPrefix DHT not started, calling start().');
@@ -975,49 +1106,64 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     }
 
     _log.fine('$logPrefix Adding self as provider for CID: ${cid.toString()}');
-    await _providerManager.addProvider(cid, AddrInfo(
-      _host.id,
-      _host.addrs,
-    ));
+    await _providerManager.addProvider(
+        cid,
+        AddrInfo(
+          _host.id,
+          _host.addrs,
+        ));
     _log.info('$logPrefix Self added as provider for CID: ${cid.toString()}');
 
     if (announce) {
-      _log.info('$logPrefix Announcing provide for CID: ${cid.toString()}. Finding closest peers...');
+      _log.info(
+          '$logPrefix Announcing provide for CID: ${cid.toString()}. Finding closest peers...');
       final result = await runLookupWithFollowup(
-        target: cid.toBytes(),
+        target: cid.multihash,
         queryFn: (peer) async {
-          final queryFnLogPrefix = '$logPrefix [provideLookup.queryFn for ${peer.toBase58().substring(0,6)}]';
-          _log.finer('$queryFnLogPrefix Sending FIND_NODE for CID ${cid.toString()}.');
+          final queryFnLogPrefix =
+              '$logPrefix [provideLookup.queryFn for ${peer.toBase58().substring(0, 6)}]';
+          _log.finer(
+              '$queryFnLogPrefix Sending FIND_NODE for CID ${cid.toString()}.');
           final message = Message(
             type: MessageType.findNode,
-            key: cid.toBytes(),
+            key: cid.multihash,
           );
           final response = await _sendMessage(peer, message);
-          _log.finer('$queryFnLogPrefix Got FIND_NODE response. CloserPeers: ${response.closerPeers.length}');
-          return response.closerPeers.map((p) => AddrInfo(
-            PeerId.fromBytes(p.id),
-            p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-          )).toList();
+          _log.finer(
+              '$queryFnLogPrefix Got FIND_NODE response. CloserPeers: ${response.closerPeers.length}');
+          return response.closerPeers
+              .map((p) => AddrInfo(
+                    PeerId.fromBytes(p.id),
+                    p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                  ))
+              .toList();
         },
         stopFn: (peerset) {
-          final stop = peerset.getClosestInStates([PeerState.queried]).length >= _options.resiliency;
-          _log.finer('$logPrefix [provideLookup.stopFn] For CID ${cid.toString()}: Queried peers: ${peerset.getClosestInStates([PeerState.queried]).length}, Resiliency: ${_options.resiliency}. Stop: $stop');
+          final stop = peerset.getClosestInStates([PeerState.queried]).length >=
+              _options.resiliency;
+          _log.finer(
+              '$logPrefix [provideLookup.stopFn] For CID ${cid.toString()}: Queried peers: ${peerset.getClosestInStates([
+                PeerState.queried
+              ]).length}, Resiliency: ${_options.resiliency}. Stop: $stop');
           return stop;
         },
       );
 
-      _log.info('$logPrefix Lookup for CID ${cid.toString()} completed. Found ${result.peers.length} peers to send ADD_PROVIDER to: ${result.peers.map((p) => p.toBase58().substring(0,6)).join(', ')}');
+      _log.info(
+          '$logPrefix Lookup for CID ${cid.toString()} completed. Found ${result.peers.length} peers to send ADD_PROVIDER to: ${result.peers.map((p) => p.toBase58().substring(0, 6)).join(', ')}');
       if (result.peers.isEmpty) {
-        _log.warning('$logPrefix No peers found by lookup for CID ${cid.toString()} to send ADD_PROVIDER messages to. Advertisement might not be effective.');
+        _log.warning(
+            '$logPrefix No peers found by lookup for CID ${cid.toString()} to send ADD_PROVIDER messages to. Advertisement might not be effective.');
       }
 
       for (final peer in result.peers) {
-        final peerShortId = peer.toBase58().substring(0,6);
+        final peerShortId = peer.toBase58().substring(0, 6);
         try {
-          _log.fine('$logPrefix Sending ADD_PROVIDER for CID ${cid.toString()} to peer $peerShortId');
+          _log.fine(
+              '$logPrefix Sending ADD_PROVIDER for CID ${cid.toString()} to peer $peerShortId');
           final message = Message(
             type: MessageType.addProvider,
-            key: cid.toBytes(),
+            key: cid.multihash,
             providerPeers: [
               Peer(
                 id: _host.id.toBytes(),
@@ -1027,13 +1173,16 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
             ],
           );
           await _sendMessageFireAndForget(peer, message);
-          _log.info('$logPrefix Successfully sent ADD_PROVIDER for CID ${cid.toString()} to peer $peerShortId');
+          _log.info(
+              '$logPrefix Successfully sent ADD_PROVIDER for CID ${cid.toString()} to peer $peerShortId');
         } catch (e, s) {
-          _log.warning('$logPrefix Error sending ADD_PROVIDER for CID ${cid.toString()} to peer $peerShortId: $e\n$s');
+          _log.warning(
+              '$logPrefix Error sending ADD_PROVIDER for CID ${cid.toString()} to peer $peerShortId: $e\n$s');
         }
       }
     } else {
-      _log.info('$logPrefix provide called with announce=false for CID: ${cid.toString()}. Not announcing to network.');
+      _log.info(
+          '$logPrefix provide called with announce=false for CID: ${cid.toString()}. Not announcing to network.');
     }
     _log.info('$logPrefix provide for CID: ${cid.toString()} completed.');
   }
@@ -1063,7 +1212,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   }
 
   /// Asynchronously searches for values for a key and adds them to the controller
-  Future<void> _searchValueAsync(String key, RoutingOptions? options, StreamController<Uint8List> controller) async {
+  Future<void> _searchValueAsync(String key, RoutingOptions? options,
+      StreamController<Uint8List> controller) async {
     try {
       if (!_started) {
         await start();
@@ -1111,10 +1261,12 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
           }
 
           // Convert the response to AddrInfo objects
-          return response.closerPeers.map((p) => AddrInfo(
-            PeerId.fromBytes(p.id),
-            p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-          )).toList();
+          return response.closerPeers
+              .map((p) => AddrInfo(
+                    PeerId.fromBytes(p.id),
+                    p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                  ))
+              .toList();
         },
         stopFn: (peerset) {
           // Check if we should stop the query
@@ -1123,7 +1275,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
           }
 
           // Stop when we've queried enough peers
-          return peerset.getClosestInStates([PeerState.queried]).length >= _options.resiliency;
+          return peerset.getClosestInStates([PeerState.queried]).length >=
+              _options.resiliency;
         },
       ).then((_) {
         // Close the value channel when the lookup is done
@@ -1136,8 +1289,10 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
       // Process values from the value channel
       var numResponses = 0;
       // Updated call to processValues with _recordValidator and adjusted callback
-      await DHTRouting.processValues(key, valCh.stream, _recordValidator, (receivedValue, isCurrentlyBest) {
-        if (isCurrentlyBest) { // Add to stream if it's the current best among valid ones
+      await DHTRouting.processValues(key, valCh.stream, _recordValidator,
+          (receivedValue, isCurrentlyBest) {
+        if (isCurrentlyBest) {
+          // Add to stream if it's the current best among valid ones
           controller.add(receivedValue.val);
         }
 
@@ -1145,7 +1300,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
         // Note: The definition of "enough responses" might change with validator logic.
         // Quorum might mean enough distinct valid values or enough peers confirming the *same* best value.
         // For now, just counting any valid value received.
-        if (quorumValue > 0 && ++numResponses >= quorumValue) { // Changed to >=
+        if (quorumValue > 0 && ++numResponses >= quorumValue) {
+          // Changed to >=
           if (!stopCh.isClosed) stopCh.close();
           return true; // Abort further processing
         }
@@ -1160,7 +1316,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   }
 
   /// Asynchronously finds providers for a CID and adds them to the controller
-  Future<void> _findProvidersAsync(CID cid, int count, StreamController<AddrInfo> controller) async {
+  Future<void> _findProvidersAsync(
+      CID cid, int count, StreamController<AddrInfo> controller) async {
     try {
       if (!_started) {
         await start();
@@ -1189,12 +1346,12 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
 
         // Find the closest peers to the CID
         final result = await runLookupWithFollowup(
-          target: cid.toBytes(),
+          target: cid.multihash,
           queryFn: (peer) async {
             // Query the peer for providers
             final message = Message(
               type: MessageType.getProviders,
-              key: cid.toBytes(),
+              key: cid.multihash,
             );
 
             // Send the message to the peer
@@ -1218,14 +1375,18 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
             }
 
             // Convert the response to AddrInfo objects for closer peers
-            return response.closerPeers.map((p) => AddrInfo(
-              PeerId.fromBytes(p.id),
-               p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-            )).toList();
+            return response.closerPeers
+                .map((p) => AddrInfo(
+                      PeerId.fromBytes(p.id),
+                      p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                    ))
+                .toList();
           },
           stopFn: (peerset) {
             // Stop when we've found enough providers or queried enough peers
-            return count <= 0 || peerset.getClosestInStates([PeerState.queried]).length >= _options.resiliency;
+            return count <= 0 ||
+                peerset.getClosestInStates([PeerState.queried]).length >=
+                    _options.resiliency;
           },
         );
       }
@@ -1240,8 +1401,9 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   @override
   Future<AddrInfo?> findPeer(PeerId id, {RoutingOptions? options}) async {
     final logPrefix = '[${_host.id.toBase58().substring(0, 6)}.findPeer]';
-    final targetShortId = id.toBase58().substring(0,6);
-    _log.info('$logPrefix Attempting to find peer $targetShortId (${id.toString()})');
+    final targetShortId = id.toBase58().substring(0, 6);
+    _log.info(
+        '$logPrefix Attempting to find peer $targetShortId (${id.toString()})');
 
     if (!_started) {
       _log.fine('$logPrefix DHT not started, calling start().');
@@ -1250,28 +1412,34 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
 
     // Always perform network lookup to verify peer reachability
     // This ensures unreachable peers are detected and evicted from routing table
-    _log.info('$logPrefix Performing network lookup for $targetShortId to verify reachability.');
-    
+    _log.info(
+        '$logPrefix Performing network lookup for $targetShortId to verify reachability.');
+
     final targetBytes = id.toBytes();
     final result = await runLookupWithFollowup(
       target: targetBytes,
       queryFn: (peer) async {
-        final queryFnLogPrefix = '$logPrefix [lookup.queryFn for ${peer.toBase58().substring(0,6)}]';
-        _log.fine('$queryFnLogPrefix Sending FIND_NODE for target $targetShortId.');
+        final queryFnLogPrefix =
+            '$logPrefix [lookup.queryFn for ${peer.toBase58().substring(0, 6)}]';
+        _log.fine(
+            '$queryFnLogPrefix Sending FIND_NODE for target $targetShortId.');
         final message = Message(
           type: MessageType.findNode,
           key: targetBytes,
         );
         final response = await _sendMessage(peer, message);
-        _log.fine('$queryFnLogPrefix Got FIND_NODE response. CloserPeers: ${response.closerPeers.length}.');
-        
+        _log.fine(
+            '$queryFnLogPrefix Got FIND_NODE response. CloserPeers: ${response.closerPeers.length}.');
+
         // Try adding the queried peer to RT; queryPeer:false as its liveness is confirmed by response.
         bool added = await _routingTable.tryAddPeer(peer, queryPeer: false);
-        _log.finer('$queryFnLogPrefix Tried adding peer ${peer.toBase58().substring(0,6)} to RT (queryPeer:false). Success: $added. Current RT size: ${await _routingTable.size()}');
-        
+        _log.finer(
+            '$queryFnLogPrefix Tried adding peer ${peer.toBase58().substring(0, 6)} to RT (queryPeer:false). Success: $added. Current RT size: ${await _routingTable.size()}');
+
         for (final p in response.closerPeers) {
           if (_bytesEqual(p.id, targetBytes)) {
-            _log.info('$queryFnLogPrefix Target peer $targetShortId found in response from ${peer.toBase58().substring(0,6)}.');
+            _log.info(
+                '$queryFnLogPrefix Target peer $targetShortId found in response from ${peer.toBase58().substring(0, 6)}.');
             // Return a list containing only the target peer to potentially stop the lookup early if stopFn allows.
             return [
               AddrInfo(
@@ -1281,60 +1449,77 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
             ];
           }
         }
-        return response.closerPeers.map((p) => AddrInfo(
-          PeerId.fromBytes(p.id),
-          p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-        )).toList();
+        return response.closerPeers
+            .map((p) => AddrInfo(
+                  PeerId.fromBytes(p.id),
+                  p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                ))
+            .toList();
       },
       stopFn: (peerset) {
-        for (final p in peerset.getClosestInStates([PeerState.queried, PeerState.waiting, PeerState.heard])) {
+        for (final p in peerset.getClosestInStates(
+            [PeerState.queried, PeerState.waiting, PeerState.heard])) {
           if (_bytesEqual(p.toBytes(), targetBytes)) {
-            _log.fine('$logPrefix [lookup.stopFn] Target peer $targetShortId found in peerset. Stopping lookup.');
+            _log.fine(
+                '$logPrefix [lookup.stopFn] Target peer $targetShortId found in peerset. Stopping lookup.');
             return true;
           }
         }
-        final stop = peerset.getClosestInStates([PeerState.queried]).length >= _options.resiliency;
+        final stop = peerset.getClosestInStates([PeerState.queried]).length >=
+            _options.resiliency;
         if (stop) {
-          _log.fine('$logPrefix [lookup.stopFn] Queried enough peers (${_options.resiliency}). Stopping lookup for $targetShortId.');
+          _log.fine(
+              '$logPrefix [lookup.stopFn] Queried enough peers (${_options.resiliency}). Stopping lookup for $targetShortId.');
         }
         return stop;
       },
     );
 
-    _log.info('$logPrefix Lookup for $targetShortId completed. TerminationReason: ${result.terminationReason}. Found ${result.peers.length} peers in result set: ${result.peers.map((p) => p.toBase58().substring(0,6)).toList()}');
-    
+    _log.info(
+        '$logPrefix Lookup for $targetShortId completed. TerminationReason: ${result.terminationReason}. Found ${result.peers.length} peers in result set: ${result.peers.map((p) => p.toBase58().substring(0, 6)).toList()}');
+
     final listEquality = ListEquality();
     for (final p_id_from_result in result.peers) {
       if (listEquality.equals(p_id_from_result.toBytes(), targetBytes)) {
-        _log.info('$logPrefix Target peer $targetShortId matched in lookup result.peers. Fetching AddrInfo from local peerstore.');
-        final peerInfoFromStore = await _host.peerStore.getPeer(p_id_from_result);
+        _log.info(
+            '$logPrefix Target peer $targetShortId matched in lookup result.peers. Fetching AddrInfo from local peerstore.');
+        final peerInfoFromStore =
+            await _host.peerStore.getPeer(p_id_from_result);
         if (peerInfoFromStore != null) {
-          _log.info('$logPrefix For target $targetShortId, AddrInfo retrieved from local peerstore. Addrs count: ${peerInfoFromStore.addrs.length}. Addrs: ${peerInfoFromStore.addrs.map((a) => a.toString()).join(", ")}.');
+          _log.info(
+              '$logPrefix For target $targetShortId, AddrInfo retrieved from local peerstore. Addrs count: ${peerInfoFromStore.addrs.length}. Addrs: ${peerInfoFromStore.addrs.map((a) => a.toString()).join(", ")}.');
           if (peerInfoFromStore.addrs.isNotEmpty) {
             return AddrInfo(p_id_from_result, peerInfoFromStore.addrs.toList());
           } else {
-            _log.warning('$logPrefix For target $targetShortId, PeerInfo found in peerstore BUT addrs list is EMPTY. Returning AddrInfo with empty addrs.');
+            _log.warning(
+                '$logPrefix For target $targetShortId, PeerInfo found in peerstore BUT addrs list is EMPTY. Returning AddrInfo with empty addrs.');
             return AddrInfo(p_id_from_result, []);
           }
         } else {
-          _log.warning('$logPrefix For target $targetShortId, PeerInfo was NOT found in local peerstore after lookup. Returning AddrInfo with empty addrs.');
+          _log.warning(
+              '$logPrefix For target $targetShortId, PeerInfo was NOT found in local peerstore after lookup. Returning AddrInfo with empty addrs.');
           return AddrInfo(p_id_from_result, []);
         }
       }
     }
-    _log.warning('$logPrefix Target peer $targetShortId was NOT found in the final result.peers list from lookup. Returning null.');
+    _log.warning(
+        '$logPrefix Target peer $targetShortId was NOT found in the final result.peers list from lookup. Returning null.');
     return null;
   }
 
   @override
-  Future<void> putValue(String key, Uint8List value, {RoutingOptions? options}) async {
+  Future<void> putValue(String key, Uint8List value,
+      {RoutingOptions? options}) async {
     final Logger putLogger = Logger('IpfsDHT.putValue');
-    putLogger.info('[${_host.id.toBase58().substring(0,6)}] putValue called for key: $key');
+    putLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] putValue called for key: $key');
 
     if (!_started) {
-      putLogger.fine('[${_host.id.toBase58().substring(0,6)}] DHT not started, calling start().');
+      putLogger.fine(
+          '[${_host.id.toBase58().substring(0, 6)}] DHT not started, calling start().');
       await start();
-      putLogger.fine('[${_host.id.toBase58().substring(0,6)}] DHT start() completed.');
+      putLogger.fine(
+          '[${_host.id.toBase58().substring(0, 6)}] DHT start() completed.');
     }
 
     // Create a record with the key and value.
@@ -1346,16 +1531,20 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
       value: Uint8List.fromList(value),
       timeReceived: DateTime.now().millisecondsSinceEpoch,
       author: _host.id.toBytes(),
-      signature: Uint8List(0), // In a real implementation, this would be a signature
+      signature:
+          Uint8List(0), // In a real implementation, this would be a signature
     );
 
     // Store the record locally
-    putLogger.fine('[${_host.id.toBase58().substring(0,6)}] Storing record locally for key: $key...');
+    putLogger.fine(
+        '[${_host.id.toBase58().substring(0, 6)}] Storing record locally for key: $key...');
     await putRecordToDatastore(record);
-    putLogger.info('[${_host.id.toBase58().substring(0,6)}] Record stored locally for key: $key. Datastore size: ${_datastore.length}');
+    putLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] Record stored locally for key: $key. Datastore size: ${_datastore.length}');
 
     // Find the closest peers to the key
-    putLogger.fine('[${_host.id.toBase58().substring(0,6)}] Finding closest peers for key: $key...');
+    putLogger.fine(
+        '[${_host.id.toBase58().substring(0, 6)}] Finding closest peers for key: $key...');
     final result = await runLookupWithFollowup(
       target: keyBytes,
       queryFn: (peer) async {
@@ -1369,14 +1558,17 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
         final response = await _sendMessage(peer, message);
 
         // Convert the response to AddrInfo objects
-        return response.closerPeers.map((p) => AddrInfo(
-          PeerId.fromBytes(p.id),
-          p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-        )).toList();
+        return response.closerPeers
+            .map((p) => AddrInfo(
+                  PeerId.fromBytes(p.id),
+                  p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                ))
+            .toList();
       },
       stopFn: (peerset) {
         // Stop when we've queried enough peers
-        return peerset.getClosestInStates([PeerState.queried]).length >= _options.resiliency;
+        return peerset.getClosestInStates([PeerState.queried]).length >=
+            _options.resiliency;
       },
     );
 
@@ -1399,7 +1591,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   @override
   Future<Uint8List?> getValue(String key, RoutingOptions? options) async {
     final Logger getValueLogger = Logger('IpfsDHT.getValue');
-    getValueLogger.info('[${_host.id.toBase58().substring(0,6)}] getValue called for key: $key. Options: $options');
+    getValueLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] getValue called for key: $key. Options: $options');
 
     if (!_started) {
       await start();
@@ -1411,15 +1604,18 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     // Check if the value is stored locally
     final localRecord = await checkLocalDatastore(keyBytes);
     if (localRecord != null) {
-      getValueLogger.info('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": Found in local datastore. Returning value.');
+      getValueLogger.info(
+          '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": Found in local datastore. Returning value.');
       return localRecord.value;
     }
-    getValueLogger.info('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": Not found in local datastore. Proceeding with network lookup.');
+    getValueLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": Not found in local datastore. Proceeding with network lookup.');
 
     final controller = StreamController<Record>();
     LookupWithFollowupResult lookupResult;
 
-    getValueLogger.info('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": About to call runLookupWithFollowup.');
+    getValueLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": About to call runLookupWithFollowup.');
     try {
       lookupResult = await runLookupWithFollowup(
         target: keyBytes,
@@ -1429,85 +1625,110 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
             key: keyBytes,
           );
           final response = await _sendMessage(peer, message);
-          getValueLogger.fine('[${_host.id.toBase58().substring(0,6)}] getValue.queryFn for key "$key" from peer ${peer.toBase58().substring(0,6)}: response.record is ${response.record != null ? "NOT null (value: ${utf8.decode(response.record!.value, allowMalformed: true)})" : "null"}. CloserPeers: ${response.closerPeers.length}');
+          getValueLogger.fine(
+              '[${_host.id.toBase58().substring(0, 6)}] getValue.queryFn for key "$key" from peer ${peer.toBase58().substring(0, 6)}: response.record is ${response.record != null ? "NOT null (value: ${utf8.decode(response.record!.value, allowMalformed: true)})" : "null"}. CloserPeers: ${response.closerPeers.length}');
           if (response.record != null) {
             if (!controller.isClosed) controller.add(response.record!);
           }
-          return response.closerPeers.map((p) => AddrInfo(
-            PeerId.fromBytes(p.id),
-            p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-          )).toList();
+          return response.closerPeers
+              .map((p) => AddrInfo(
+                    PeerId.fromBytes(p.id),
+                    p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                  ))
+              .toList();
         },
         stopFn: (peerset) {
-          return peerset.getClosestInStates([PeerState.queried]).length >= _options.resiliency;
+          return peerset.getClosestInStates([PeerState.queried]).length >=
+              _options.resiliency;
         },
       );
     } catch (e, s) {
-      getValueLogger.severe('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": runLookupWithFollowup call FAILED directly: $e\n$s', e, s);
-      if (e is MaxRetriesExceededException) { // If runLookupWithFollowup itself somehow throws this
+      getValueLogger.severe(
+          '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": runLookupWithFollowup call FAILED directly: $e\n$s',
+          e,
+          s);
+      if (e is MaxRetriesExceededException) {
+        // If runLookupWithFollowup itself somehow throws this
         throw e;
       }
       // For other catastrophic errors from runLookupWithFollowup, wrap and rethrow or handle as appropriate.
       // For now, let's assume it means no value can be retrieved.
-      throw Exception('Lookup process for key "$key" failed catastrophically: $e');
+      throw Exception(
+          'Lookup process for key "$key" failed catastrophically: $e');
     } finally {
-        if (!controller.isClosed) {
-            getValueLogger.fine('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": Closing record controller in finally block after runLookupWithFollowup.');
-            controller.close();
-        }
+      if (!controller.isClosed) {
+        getValueLogger.fine(
+            '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": Closing record controller in finally block after runLookupWithFollowup.');
+        controller.close();
+      }
     }
-    
-    getValueLogger.info('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": runLookupWithFollowup completed. TerminationReason: ${lookupResult.terminationReason}, ErrorsInResult: ${lookupResult.errors.length}');
+
+    getValueLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": runLookupWithFollowup completed. TerminationReason: ${lookupResult.terminationReason}, ErrorsInResult: ${lookupResult.errors.length}');
     for (final err in lookupResult.errors) {
-        getValueLogger.warning('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": Error reported in lookupResult: $err');
+      getValueLogger.warning(
+          '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": Error reported in lookupResult: $err');
     }
 
     List<Record> receivedRecords = [];
     await for (final record in controller.stream) {
-        receivedRecords.add(record);
+      receivedRecords.add(record);
     }
-    getValueLogger.info('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": Collected ${receivedRecords.length} records from controller stream.');
+    getValueLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": Collected ${receivedRecords.length} records from controller stream.');
 
-    final maxRetriesError = lookupResult.errors.firstWhereOrNull((err) => err is MaxRetriesExceededException);
+    final maxRetriesError = lookupResult.errors
+        .firstWhereOrNull((err) => err is MaxRetriesExceededException);
 
     if (receivedRecords.isEmpty) {
       if (maxRetriesError != null) {
-        getValueLogger.warning('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": No records received AND MaxRetriesExceededException found in lookup result. Rethrowing.');
+        getValueLogger.warning(
+            '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": No records received AND MaxRetriesExceededException found in lookup result. Rethrowing.');
         throw maxRetriesError;
       }
-      getValueLogger.info('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": No records received from network (after processing controller). Returning null.');
-      return null; 
+      getValueLogger.info(
+          '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": No records received from network (after processing controller). Returning null.');
+      return null;
     }
-    
-    getValueLogger.info('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": Received ${receivedRecords.length} records from network. Proceeding with validation.');
+
+    getValueLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": Received ${receivedRecords.length} records from network. Proceeding with validation.');
 
     List<Uint8List> validRecordValues = [];
     for (final record in receivedRecords) {
-        try {
-            getValueLogger.finer('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": Validating record (${record.value.length} bytes)');
-            _recordValidator.validate(key, record.value); 
-            getValueLogger.finer('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": Record PASSED validation.');
-            validRecordValues.add(record.value);
-        } catch (e) {
-            getValueLogger.warning('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": Record failed validation: $e.');
-        }
+      try {
+        getValueLogger.finer(
+            '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": Validating record (${record.value.length} bytes)');
+        _recordValidator.validate(key, record.value);
+        getValueLogger.finer(
+            '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": Record PASSED validation.');
+        validRecordValues.add(record.value);
+      } catch (e) {
+        getValueLogger.warning(
+            '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": Record failed validation: $e.');
+      }
     }
 
     if (validRecordValues.isEmpty) {
-        if (maxRetriesError != null) {
-            getValueLogger.warning('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": No VALID records AND MaxRetriesExceededException found in lookup result. Rethrowing.');
-            throw maxRetriesError;
-        }
-        getValueLogger.warning('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": No records passed validation. Returning null.');
-        return null;
+      if (maxRetriesError != null) {
+        getValueLogger.warning(
+            '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": No VALID records AND MaxRetriesExceededException found in lookup result. Rethrowing.');
+        throw maxRetriesError;
+      }
+      getValueLogger.warning(
+          '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": No records passed validation. Returning null.');
+      return null;
     }
-    
-    getValueLogger.info('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": ${validRecordValues.length} records passed validation. Selecting best.');
 
-    final bestValueIndex = await _recordValidator.select(key, validRecordValues);
+    getValueLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": ${validRecordValues.length} records passed validation. Selecting best.');
+
+    final bestValueIndex =
+        await _recordValidator.select(key, validRecordValues);
     final bestValue = validRecordValues[bestValueIndex];
-    
-    getValueLogger.info('[${_host.id.toBase58().substring(0,6)}] getValue for key "$key": final bestValue selected (len: ${bestValue.length}). Returning value.');
+
+    getValueLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] getValue for key "$key": final bestValue selected (len: ${bestValue.length}). Returning value.');
     return bestValue;
   }
 
@@ -1515,7 +1736,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   Future<Message> _sendMessage(PeerId peer, Message message) async {
     final String shortPeerId = peer.toBase58().substring(0, 6);
     final String selfShortId = _host.id.toBase58().substring(0, 6);
-    _log.info('[$selfShortId] Attempting to send ${message.type} to $shortPeerId. Key: ${message.key != null ? base64Encode(message.key!) : 'N/A'}');
+    _log.info(
+        '[$selfShortId] Attempting to send ${message.type} to $shortPeerId. Key: ${message.key != null ? base64Encode(message.key!) : 'N/A'}');
 
     int attempt = 0;
     dynamic lastError;
@@ -1526,97 +1748,137 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
       List<int> responseBytes = [];
 
       try {
-        _log.fine('[$selfShortId] Attempt $attempt: Dialing $shortPeerId for ${message.type}.');
-        await dialPeer(peer); // dialPeer includes its own logging and rethrows on failure
-        _log.fine('[$selfShortId] Attempt $attempt: Dial to $shortPeerId successful. Opening new stream.');
+        _log.fine(
+            '[$selfShortId] Attempt $attempt: Dialing $shortPeerId for ${message.type}.');
+        await dialPeer(
+            peer); // dialPeer includes its own logging and rethrows on failure
+        _log.fine(
+            '[$selfShortId] Attempt $attempt: Dial to $shortPeerId successful. Opening new stream.');
 
         // Create stream with timeout but handle timeout exceptions gracefully
         // This maintains protection against hanging operations while preventing app crashes
         try {
-          stream = await _host.newStream(peer, [AminoConstants.protocolID], Context())
+          stream = await _host
+              .newStream(peer, [AminoConstants.protocolID], Context())
               .timeout(Duration(seconds: 10)) as P2PStream<Uint8List>?;
         } on TimeoutException catch (e) {
-          _log.warning('[$selfShortId] Attempt $attempt: Stream creation timed out for $shortPeerId: $e');
+          _log.warning(
+              '[$selfShortId] Attempt $attempt: Stream creation timed out for $shortPeerId: $e');
           throw Exception('Stream creation timed out: $e');
         }
-        
-        if (stream == null) { // Should not happen if newStream throws on failure, but good for robustness
+
+        if (stream == null) {
+          // Should not happen if newStream throws on failure, but good for robustness
           throw Exception('Failed to create stream, newStream returned null.');
         }
-        _log.fine('[$selfShortId] Attempt $attempt: Stream ${stream!.id()} opened to $shortPeerId.');
+        _log.fine(
+            '[$selfShortId] Attempt $attempt: Stream ${stream!.id()} opened to $shortPeerId.');
 
         final messageBytes = encodeMessage(message);
-        _log.fine('[$selfShortId] Attempt $attempt: Writing protobuf message to stream ${stream.id()} (Size: ${messageBytes.length})');
-        
-        // Add timeout protection to stream operations
-        await stream.write(messageBytes).timeout(Duration(seconds: 5), onTimeout: () {
-          _log.warning('[$selfShortId] Attempt $attempt: Write operation timed out for $shortPeerId');
-          throw TimeoutException('Write operation timed out', Duration(seconds: 5));
-        });
-        
-        _log.fine('[$selfShortId] Attempt $attempt: Message written to stream ${stream.id()}. Reading response...');
+        _log.fine(
+            '[$selfShortId] Attempt $attempt: Writing protobuf message to stream ${stream.id()} (Size: ${messageBytes.length})');
 
-        responseBytes = await stream.read().timeout(Duration(seconds: 10), onTimeout: () {
-          _log.warning('[$selfShortId] Attempt $attempt: Read operation timed out for $shortPeerId');
-          throw TimeoutException('Read operation timed out', Duration(seconds: 10));
+        // Add timeout protection to stream operations
+        await stream.write(messageBytes).timeout(Duration(seconds: 5),
+            onTimeout: () {
+          _log.warning(
+              '[$selfShortId] Attempt $attempt: Write operation timed out for $shortPeerId');
+          throw TimeoutException(
+              'Write operation timed out', Duration(seconds: 5));
         });
-        
-        _log.info('[$selfShortId] Attempt $attempt: Response received from $shortPeerId on stream ${stream.id()}. Length: ${responseBytes.length}');
-        
+
+        _log.fine(
+            '[$selfShortId] Attempt $attempt: Message written to stream ${stream.id()}. Reading response...');
+
+        responseBytes =
+            await stream.read().timeout(Duration(seconds: 10), onTimeout: () {
+          _log.warning(
+              '[$selfShortId] Attempt $attempt: Read operation timed out for $shortPeerId');
+          throw TimeoutException(
+              'Read operation timed out', Duration(seconds: 10));
+        });
+
+        _log.info(
+            '[$selfShortId] Attempt $attempt: Response received from $shortPeerId on stream ${stream.id()}. Length: ${responseBytes.length}');
+
         await stream.close();
-        _log.fine('[$selfShortId] Attempt $attempt: Client-side stream ${stream.id()} closed after successful communication.');
-        
+        _log.fine(
+            '[$selfShortId] Attempt $attempt: Client-side stream ${stream.id()} closed after successful communication.');
+
         stream = null; // Clear stream variable after successful close
 
         // Parse the protobuf response
         Message responseMessage;
         try {
           responseMessage = decodeMessage(Uint8List.fromList(responseBytes));
-          _log.info('[$selfShortId] Attempt $attempt: Parsed ${responseMessage.type} response from $shortPeerId. Success.');
+          _log.info(
+              '[$selfShortId] Attempt $attempt: Parsed ${responseMessage.type} response from $shortPeerId. Success.');
           if (responseMessage.record != null) {
-            _log.finer('[$selfShortId] Received record in response: key=${base64Encode(responseMessage.record!.key)}, value=${base64Encode(responseMessage.record!.value)} (decoded: ${utf8.decode(responseMessage.record!.value, allowMalformed: true)})');
+            _log.finer(
+                '[$selfShortId] Received record in response: key=${base64Encode(responseMessage.record!.key)}, value=${base64Encode(responseMessage.record!.value)} (decoded: ${utf8.decode(responseMessage.record!.value, allowMalformed: true)})');
           }
           return responseMessage;
         } catch (e, s) {
-          _log.severe('[$selfShortId] Attempt $attempt: Error decoding protobuf response from $shortPeerId. Length: ${responseBytes.length}. Error: $e', e, s);
-          throw Exception('Failed to decode protobuf response from $shortPeerId: $e');
+          _log.severe(
+              '[$selfShortId] Attempt $attempt: Error decoding protobuf response from $shortPeerId. Length: ${responseBytes.length}. Error: $e',
+              e,
+              s);
+          throw Exception(
+              'Failed to decode protobuf response from $shortPeerId: $e');
         }
-
       } catch (e, s) {
         lastError = e;
-        _log.warning('[$selfShortId] Attempt $attempt to send ${message.type} to $shortPeerId failed: $e', e, s);
+        _log.warning(
+            '[$selfShortId] Attempt $attempt to send ${message.type} to $shortPeerId failed: $e',
+            e,
+            s);
 
         if (stream != null) {
           try {
             await stream!.reset(); // Use reset for abrupt closure on error
-            _log.fine('[$selfShortId] Stream ${stream.id()} reset after error on attempt $attempt.');
+            _log.fine(
+                '[$selfShortId] Stream ${stream.id()} reset after error on attempt $attempt.');
           } catch (resetErr, resetStack) {
-            _log.warning('[$selfShortId] Error resetting stream ${stream.id()} after error on attempt $attempt: $resetErr', resetErr, resetStack);
+            _log.warning(
+                '[$selfShortId] Error resetting stream ${stream.id()} after error on attempt $attempt: $resetErr',
+                resetErr,
+                resetStack);
           }
           stream = null;
         }
 
-        if (_isRetryableConnectionError(e) && attempt < _options.maxRetryAttempts) {
-          num baseBackoffMillis = _options.retryInitialBackoff.inMilliseconds * math.pow(_options.retryBackoffFactor, attempt - 1);
+        if (_isRetryableConnectionError(e) &&
+            attempt < _options.maxRetryAttempts) {
+          num baseBackoffMillis = _options.retryInitialBackoff.inMilliseconds *
+              math.pow(_options.retryBackoffFactor, attempt - 1);
           double currentBackoffMillis = baseBackoffMillis.toDouble();
 
           if (currentBackoffMillis > _options.retryMaxBackoff.inMilliseconds) {
-            currentBackoffMillis = _options.retryMaxBackoff.inMilliseconds.toDouble();
+            currentBackoffMillis =
+                _options.retryMaxBackoff.inMilliseconds.toDouble();
           }
           // Add jitter: +/- 20% of current backoff
           final jitterRange = currentBackoffMillis * 0.2;
-          final jitter = (math.Random().nextDouble() * (2 * jitterRange)) - jitterRange;
+          final jitter =
+              (math.Random().nextDouble() * (2 * jitterRange)) - jitterRange;
           final delayMillis = (currentBackoffMillis + jitter).toInt();
-          final delay = Duration(milliseconds: math.max(0, delayMillis)); // Ensure non-negative
+          final delay = Duration(
+              milliseconds: math.max(0, delayMillis)); // Ensure non-negative
 
-          _log.info('[$selfShortId] Retryable error on attempt $attempt for ${message.type} to $shortPeerId. Retrying in $delay...');
+          _log.info(
+              '[$selfShortId] Retryable error on attempt $attempt for ${message.type} to $shortPeerId. Retrying in $delay...');
           await Future.delayed(delay);
           continue; // Next attempt
         } else {
-          _log.severe('[$selfShortId] Final attempt $attempt failed for ${message.type} to $shortPeerId or error not retryable: $e', e, s);
-          if (_isRetryableConnectionError(e)) { // Max attempts reached for a retryable error
+          _log.severe(
+              '[$selfShortId] Final attempt $attempt failed for ${message.type} to $shortPeerId or error not retryable: $e',
+              e,
+              s);
+          if (_isRetryableConnectionError(e)) {
+            // Max attempts reached for a retryable error
             throw MaxRetriesExceededException(
-                'Failed to send ${message.type} to ${peer.toBase58()} after $attempt attempts', e);
+                'Failed to send ${message.type} to ${peer.toBase58()} after $attempt attempts',
+                e);
           }
           rethrow; // Non-retryable error
         }
@@ -1624,7 +1886,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     }
     // Should not be reached if logic is correct, but as a safeguard:
     throw MaxRetriesExceededException(
-        'Exhausted retries sending ${message.type} to ${peer.toBase58()} after $attempt attempts', lastError);
+        'Exhausted retries sending ${message.type} to ${peer.toBase58()} after $attempt attempts',
+        lastError);
   }
 
   /// Sends a message to a peer without expecting a response (fire-and-forget).
@@ -1632,13 +1895,15 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   Future<void> _sendMessageFireAndForget(PeerId peer, Message message) async {
     final String shortPeerId = peer.toBase58().substring(0, 6);
     final String selfShortId = _host.id.toBase58().substring(0, 6);
-    _log.info('[$selfShortId] Sending fire-and-forget ${message.type} to $shortPeerId');
+    _log.info(
+        '[$selfShortId] Sending fire-and-forget ${message.type} to $shortPeerId');
 
     P2PStream<Uint8List>? stream;
     try {
       await dialPeer(peer);
 
-      stream = await _host.newStream(peer, [AminoConstants.protocolID], Context())
+      stream = await _host
+          .newStream(peer, [AminoConstants.protocolID], Context())
           .timeout(Duration(seconds: 10)) as P2PStream<Uint8List>?;
 
       if (stream == null) {
@@ -1649,11 +1914,17 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
       await stream.write(messageBytes).timeout(Duration(seconds: 5));
       await stream.close();
       stream = null;
-      _log.info('[$selfShortId] Fire-and-forget ${message.type} sent to $shortPeerId');
+      _log.info(
+          '[$selfShortId] Fire-and-forget ${message.type} sent to $shortPeerId');
     } catch (e, s) {
-      _log.warning('[$selfShortId] Fire-and-forget ${message.type} to $shortPeerId failed: $e', e, s);
+      _log.warning(
+          '[$selfShortId] Fire-and-forget ${message.type} to $shortPeerId failed: $e',
+          e,
+          s);
       if (stream != null) {
-        try { await stream!.reset(); } catch (_) {}
+        try {
+          await stream!.reset();
+        } catch (_) {}
       }
       rethrow;
     }
@@ -1699,7 +1970,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
           errorString.contains('host is down') ||
           errorString.contains('broken pipe') ||
           errorString.contains('socketexception') || // Generic socket issues
-          errorString.contains('os error: connection timed out')) { // OS-level timeout
+          errorString.contains('os error: connection timed out')) {
+        // OS-level timeout
         return true;
       }
     }
@@ -1709,7 +1981,7 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   }
 
   /// Runs a lookup with followup using the new QueryRunner implementation.
-  /// 
+  ///
   /// This replaces the old broken query implementation with our robust QueryRunner.
   /// Maintains API compatibility with the existing DHT operations.
   Future<LookupWithFollowupResult> runLookupWithFollowup({
@@ -1717,9 +1989,10 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     required Future<List<AddrInfo>> Function(PeerId peer) queryFn,
     required bool Function(QueryPeerset peerset) stopFn,
   }) async {
-    final id =_host.id.toBase58();
-    final logPrefix = '[${id.substring(id.length -6)}.runLookupWithFollowup]';
-    _log.info('$logPrefix Starting lookup for target: ${base64Encode(target).substring(0, 10)}...');
+    final id = _host.id.toBase58();
+    final logPrefix = '[${id.substring(id.length - 6)}.runLookupWithFollowup]';
+    _log.info(
+        '$logPrefix Starting lookup for target: ${base64Encode(target).substring(0, 10)}...');
 
     // Get bootstrap peers for the query
     final bootstrapPeers = await getBootstrapPeers();
@@ -1738,7 +2011,8 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
       queryFn: queryFn,
       stopFn: stopFn,
       initialPeers: bootstrapPeers.map((p) => p.id).toList(),
-      alpha: _options.resiliency, // Use DHT's resiliency setting for concurrency
+      alpha:
+          _options.resiliency, // Use DHT's resiliency setting for concurrency
       timeout: Duration(seconds: 30), // Configurable timeout
     );
 
@@ -1748,13 +2022,19 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
     try {
       // Run the query
       final result = await runner.run();
-      
-      _log.info('$logPrefix Query completed with reason: ${result.reason}. Found ${result.peerset.getClosestInStates([PeerState.queried, PeerState.heard]).length} peers');
+
+      _log.info(
+          '$logPrefix Query completed with reason: ${result.reason}. Found ${result.peerset.getClosestInStates([
+            PeerState.queried,
+            PeerState.heard
+          ]).length} peers');
 
       // Handle peer eviction for failed queries — with liveness check
-      final unreachablePeers = result.peerset.getClosestInStates([PeerState.unreachable]);
+      final unreachablePeers =
+          result.peerset.getClosestInStates([PeerState.unreachable]);
       if (unreachablePeers.isNotEmpty) {
-        _log.info('$logPrefix ${unreachablePeers.length} peers marked unreachable, performing liveness checks before eviction');
+        _log.info(
+            '$logPrefix ${unreachablePeers.length} peers marked unreachable, performing liveness checks before eviction');
         for (final peer in unreachablePeers) {
           bool reachable = false;
           try {
@@ -1766,12 +2046,15 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
           if (!reachable) {
             try {
               await _routingTable.removePeer(peer);
-              _log.fine('$logPrefix Evicted peer ${peer.toBase58().substring(0,6)} from routing table after failed liveness check');
+              _log.fine(
+                  '$logPrefix Evicted peer ${peer.toBase58().substring(0, 6)} from routing table after failed liveness check');
             } catch (e) {
-              _log.warning('$logPrefix Failed to evict peer ${peer.toBase58().substring(0,6)} from routing table: $e');
+              _log.warning(
+                  '$logPrefix Failed to evict peer ${peer.toBase58().substring(0, 6)} from routing table: $e');
             }
           } else {
-            _log.info('$logPrefix Peer ${peer.toBase58().substring(0,6)} survived eviction via liveness ping');
+            _log.info(
+                '$logPrefix Peer ${peer.toBase58().substring(0, 6)} survived eviction via liveness ping');
           }
         }
       }
@@ -1817,44 +2100,55 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   // --- Discovery Interface Methods ---
 
   @override
-  Future<Duration> advertise(String ns, [List<DiscoveryOption> options = const []]) async {
+  Future<Duration> advertise(String ns,
+      [List<DiscoveryOption> options = const []]) async {
     final Logger advertiseLogger = Logger('IpfsDHT.advertise');
-    advertiseLogger.info('[${_host.id.toBase58().substring(0,6)}] advertise called for namespace: "$ns"');
+    advertiseLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] advertise called for namespace: "$ns"');
 
     if (!_started) {
-      advertiseLogger.fine('[${_host.id.toBase58().substring(0,6)}] DHT not started, calling start().');
+      advertiseLogger.fine(
+          '[${_host.id.toBase58().substring(0, 6)}] DHT not started, calling start().');
       await start();
-      advertiseLogger.fine('[${_host.id.toBase58().substring(0,6)}] DHT start() completed.');
+      advertiseLogger.fine(
+          '[${_host.id.toBase58().substring(0, 6)}] DHT start() completed.');
     }
 
     // final discoveryOpts = DiscoveryOptions().apply(options); // Process options if needed for TTL later
     // For now, the TTL of the advertisement is governed by the DHT's provider record validity.
-    advertiseLogger.fine('[${_host.id.toBase58().substring(0,6)}] Converting namespace "$ns" to CID.');
-    final cid = CID.fromString(ns); // Ensure this CID conversion is robust for namespaces.
-                                    // Consider if namespaces need a specific prefix or format
-                                    // before being turned into CIDs.
-    advertiseLogger.info('[${_host.id.toBase58().substring(0,6)}] Namespace "$ns" converted to CID: ${cid.toString()}. Calling provide(announce: true).');
+    advertiseLogger.fine(
+        '[${_host.id.toBase58().substring(0, 6)}] Converting namespace "$ns" to CID.');
+    final cid = CID
+        .fromString(ns); // Ensure this CID conversion is robust for namespaces.
+    // Consider if namespaces need a specific prefix or format
+    // before being turned into CIDs.
+    advertiseLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] Namespace "$ns" converted to CID: ${cid.toString()}. Calling provide(announce: true).');
 
     // Announce that this node provides the "content" identified by the namespace CID.
     // The `provide` method internally uses `_providerManager.addProvider`
     // and then announces to the network.
     await provide(cid, true); // true to announce
-    advertiseLogger.info('[${_host.id.toBase58().substring(0,6)}] provide(announce: true) for CID ${cid.toString()} completed.');
+    advertiseLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] provide(announce: true) for CID ${cid.toString()} completed.');
 
     // Return the effective TTL of this advertisement.
     // This would be the duration for which provider records are kept.
-    advertiseLogger.info('[${_host.id.toBase58().substring(0,6)}] Advertisement for "$ns" (CID: ${cid.toString()}) completed. Returning TTL: ${_options.provideValidity}');
+    advertiseLogger.info(
+        '[${_host.id.toBase58().substring(0, 6)}] Advertisement for "$ns" (CID: ${cid.toString()}) completed. Returning TTL: ${_options.provideValidity}');
     return _options.provideValidity;
   }
 
   @override
-  Future<Stream<AddrInfo>> findPeers(String ns, [List<DiscoveryOption> options = const []]) async {
+  Future<Stream<AddrInfo>> findPeers(String ns,
+      [List<DiscoveryOption> options = const []]) async {
     if (!_started) {
       await start();
     }
 
     final discoveryOpts = DiscoveryOptions().apply(options);
-    final effectiveLimit = discoveryOpts.limit ?? 0; // 0 for unbounded in findProvidersAsync
+    final effectiveLimit =
+        discoveryOpts.limit ?? 0; // 0 for unbounded in findProvidersAsync
 
     final cid = CID.fromString(ns); // Same ns to CID consideration as above.
 
@@ -1870,51 +2164,59 @@ class IpfsDHT implements Routing, Discovery { // Added Discovery interface
   /// Performs a refresh query to discover peers for a given key
   Future<void> _performRefreshQuery(String key) async {
     if (!_started) return;
-    
+
     final cplToQuery = int.tryParse(key);
     if (cplToQuery == null) {
       _log.fine('RefreshQuery: key "$key" is not a CPL, skipping.');
       return;
     }
-    
+
     _log.fine('RefreshQuery: Performing lookup for CPL $cplToQuery');
-    
+
     try {
       // Generate a target key for this CPL
       final targetKey = await _routingTable.genRandomPeerIdWithCpl(cplToQuery);
-      
+
       // Perform a network query to discover peers
-      final result = await getClosestPeers(targetKey, networkQueryEnabled: true);
-      
+      final result =
+          await getClosestPeers(targetKey, networkQueryEnabled: true);
+
       // Add discovered peers to routing table
       var addedCount = 0;
       for (final addrInfo in result) {
-        if (addrInfo.id != _host.id) { // Don't add self
-          final added = await _routingTable.tryAddPeer(addrInfo.id, queryPeer: true);
+        if (addrInfo.id != _host.id) {
+          // Don't add self
+          final added =
+              await _routingTable.tryAddPeer(addrInfo.id, queryPeer: true);
           if (added) {
             addedCount++;
             // Store addresses in peerstore
-            await _host.peerStore.addrBook.addAddrs(addrInfo.id, addrInfo.addrs, Duration(hours: 1));
+            await _host.peerStore.addrBook
+                .addAddrs(addrInfo.id, addrInfo.addrs, Duration(hours: 1));
           }
         }
       }
-      
-      _log.fine('RefreshQuery: Added $addedCount new peers for CPL $cplToQuery');
+
+      _log.fine(
+          'RefreshQuery: Added $addedCount new peers for CPL $cplToQuery');
     } catch (e, s) {
-      _log.warning('RefreshQuery: Error during query for CPL $cplToQuery: $e', e, s);
+      _log.warning(
+          'RefreshQuery: Error during query for CPL $cplToQuery: $e', e, s);
     }
   }
 
   /// Performs a ping to verify peer connectivity
   Future<void> _performRefreshPing(PeerId peerId) async {
     if (!_started) return;
-    
+
     try {
       // Try to dial the peer to verify connectivity
       await dialPeer(peerId);
-      _log.fine('RefreshPing: Successfully pinged ${peerId.toBase58().substring(0, 6)}');
+      _log.fine(
+          'RefreshPing: Successfully pinged ${peerId.toBase58().substring(0, 6)}');
     } catch (e) {
-      _log.fine('RefreshPing: Failed to ping ${peerId.toBase58().substring(0, 6)}: $e');
+      _log.fine(
+          'RefreshPing: Failed to ping ${peerId.toBase58().substring(0, 6)}: $e');
       // Remove unreachable peer from routing table
       await _routingTable.removePeer(peerId);
     }

--- a/lib/src/dht/v2/managers/network_manager.dart
+++ b/lib/src/dht/v2/managers/network_manager.dart
@@ -16,7 +16,7 @@ import '../errors/dht_errors.dart';
 import 'metrics_manager.dart';
 
 /// Manages network operations for DHT v2
-/// 
+///
 /// This component handles:
 /// - Message sending and receiving
 /// - Connection management
@@ -25,19 +25,19 @@ import 'metrics_manager.dart';
 /// - Timeout management
 class NetworkManager {
   static final Logger _logger = Logger('NetworkManager');
-  
+
   final Host _host;
-  
+
   // Configuration
   DHTConfigV2? _config;
   MetricsManager? _metrics;
-  
+
   // State
   bool _started = false;
   bool _closed = false;
-  
+
   NetworkManager(this._host);
-  
+
   /// Initializes the network manager
   void initialize({
     required DHTConfigV2 config,
@@ -46,54 +46,59 @@ class NetworkManager {
     _config = config;
     _metrics = metrics;
   }
-  
+
   /// Starts the network manager
   Future<void> start() async {
     if (_started || _closed) return;
-    
+
     _logger.info('Starting NetworkManager...');
     _started = true;
     _logger.info('NetworkManager started');
   }
-  
+
   /// Stops the network manager
   Future<void> close() async {
     if (_closed) return;
     _closed = true;
-    
+
     _logger.info('Closing NetworkManager...');
     _logger.info('NetworkManager closed');
   }
-  
+
   /// Sends a message to a peer with retry logic and error handling
-  /// 
+  ///
   /// This method provides consistent error handling and retry logic
   /// across all DHT operations, fixing the inconsistencies in the
   /// original implementation.
   Future<Message> sendMessage(PeerId peer, Message message) async {
     _ensureStarted();
-    
+
     final peerShortId = peer.toBase58().substring(0, 6);
     final selfShortId = _host.id.toBase58().substring(0, 6);
-    
+
     // Check for self-messaging before entering retry logic (permanent failure)
     if (peer == _host.id) {
       _logger.fine('[$selfShortId] Skipping self-message for $peerShortId');
       throw DHTNetworkException('Cannot send message to self', peerId: peer);
     }
-    
+
     _logger.info('[$selfShortId] Sending ${message.type} to $peerShortId');
     _metrics?.recordNetworkRequest();
-    
+
     try {
       final result = await DHTErrorHandler.handleQueryError(
-        () => _sendMessageWithRetry(peer, message),
-        peer,
-        maxRetries: _config?.maxRetryAttempts ?? 3,
-        initialBackoff: _config?.retryInitialBackoff ?? Duration(milliseconds: 500),
-        context: 'sendMessage',
-      ) ?? (throw DHTNetworkException('Failed to send message after all retries', peerId: peer));
-      
+            () => _sendMessageWithRetry(peer, message),
+            peer,
+            maxRetries: _config?.maxRetryAttempts ?? 3,
+            initialBackoff:
+                _config?.retryInitialBackoff ?? Duration(milliseconds: 500),
+            context: 'sendMessage',
+          ) ??
+          (throw DHTNetworkException(
+            'Failed to send message after all retries',
+            peerId: peer,
+          ));
+
       // Record success for the overall operation
       _metrics?.recordNetworkSuccess();
       return result;
@@ -101,7 +106,8 @@ class NetworkManager {
       // Record failure for the overall operation
       if (e is DHTTimeoutException) {
         _metrics?.recordNetworkTimeout(peer: peer);
-      } else if (e is DHTMaxRetriesException && e.cause is DHTTimeoutException) {
+      } else if (e is DHTMaxRetriesException &&
+          e.cause is DHTTimeoutException) {
         // If the max retries exception was caused by a timeout, record it as a timeout
         _metrics?.recordNetworkTimeout(peer: peer);
       } else {
@@ -110,25 +116,27 @@ class NetworkManager {
       rethrow;
     }
   }
-  
+
   /// Internal method to send a message with retry logic
   Future<Message> _sendMessageWithRetry(PeerId peer, Message message) async {
     final peerShortId = peer.toBase58().substring(0, 6);
     final selfShortId = _host.id.toBase58().substring(0, 6);
-    
+
     final stopwatch = Stopwatch()..start();
-    
+
     try {
       // Create stream with timeout
       final stream = await _createStream(peer);
-      
+
       try {
         // Send the message
         final responseMessage = await _exchangeMessage(stream, message);
-        
+
         stopwatch.stop();
-        _logger.fine('[$selfShortId] Successfully received response from $peerShortId in ${stopwatch.elapsedMilliseconds}ms');
-        
+        _logger.fine(
+          '[$selfShortId] Successfully received response from $peerShortId in ${stopwatch.elapsedMilliseconds}ms',
+        );
+
         return responseMessage;
       } finally {
         // Always close the stream
@@ -140,7 +148,7 @@ class NetworkManager {
       }
     } catch (e) {
       stopwatch.stop();
-      
+
       if (e is TimeoutException) {
         throw DHTTimeoutException(
           'Network operation timed out after ${stopwatch.elapsedMilliseconds}ms',
@@ -160,26 +168,26 @@ class NetworkManager {
       }
     }
   }
-  
+
   /// Creates a stream to the peer with timeout
   Future<P2PStream> _createStream(PeerId peer) async {
     final timeout = _config?.networkTimeout ?? Duration(seconds: 30);
-    
+
     try {
-      final stream = await _host.newStream(
-        peer,
-        [AminoConstants.protocolID],
-        Context(),
-      ).timeout(timeout);
-      
+      final stream = await _host
+          .newStream(peer, [AminoConstants.protocolID], Context())
+          .timeout(timeout);
+
       _logger.fine('Stream created to ${peer.toBase58().substring(0, 6)}');
       _metrics?.recordConnectionOpened();
-      
+
       return stream;
     } on IdentifyTimeoutException catch (e) {
       // Handle identify protocol timeout specifically
       // This can happen when the remote peer is unreachable or the connection is stale
-      _logger.warning('Identify timeout creating stream to ${peer.toBase58().substring(0, 6)}: ${e.message}');
+      _logger.warning(
+        'Identify timeout creating stream to ${peer.toBase58().substring(0, 6)}: ${e.message}',
+      );
       throw DHTTimeoutException(
         'Stream creation failed due to identify timeout',
         e.timeout ?? timeout,
@@ -188,7 +196,9 @@ class NetworkManager {
       );
     } on IdentifyException catch (e) {
       // Handle other identify protocol failures
-      _logger.warning('Identify failed creating stream to ${peer.toBase58().substring(0, 6)}: ${e.message}');
+      _logger.warning(
+        'Identify failed creating stream to ${peer.toBase58().substring(0, 6)}: ${e.message}',
+      );
       throw DHTNetworkException(
         'Stream creation failed due to identify error: ${e.message}',
         peerId: peer,
@@ -209,21 +219,24 @@ class NetworkManager {
       );
     }
   }
-  
+
   /// Exchanges a message over the stream
   Future<Message> _exchangeMessage(P2PStream stream, Message message) async {
     final timeout = _config?.networkTimeout ?? Duration(seconds: 30);
-    
+
     try {
       // Serialize and send the protobuf message
       final messageBytes = encodeMessage(message);
 
-      _logger.fine('Sending message: ${message.type} (${messageBytes.length} bytes)');
+      _logger.fine(
+        'Sending message: ${message.type} (${messageBytes.length} bytes)',
+      );
 
       await stream.write(messageBytes);
 
-      // Read the response with timeout
-      final responseBytes = await stream.read().timeout(timeout);
+      // Read the full varint-length-prefixed protobuf frame. A single stream
+      // read can return only part of the frame on real network transports.
+      final responseBytes = await _readDhtFrame(stream).timeout(timeout);
 
       _logger.fine('Received response: ${responseBytes.length} bytes');
 
@@ -238,13 +251,54 @@ class NetworkManager {
         cause: e,
       );
     } catch (e) {
-      throw DHTProtocolException(
-        'Message exchange failed: $e',
-        cause: e,
-      );
+      throw DHTProtocolException('Message exchange failed: $e', cause: e);
     }
   }
-  
+
+  Future<Uint8List> _readDhtFrame(P2PStream stream) async {
+    final prefix = <int>[];
+    var length = 0;
+    var shift = 0;
+    while (true) {
+      final chunk = await stream.read(1);
+      if (chunk.isEmpty) {
+        throw const FormatException('DHT stream closed before frame length');
+      }
+      final byte = chunk[0];
+      prefix.add(byte);
+      length |= (byte & 0x7f) << shift;
+      if (byte & 0x80 == 0) {
+        break;
+      }
+      shift += 7;
+      if (shift > 28) {
+        throw const FormatException('DHT frame length varint is too long');
+      }
+    }
+    final payload = await _readExact(stream, length);
+    final framed = Uint8List(prefix.length + payload.length);
+    framed.setRange(0, prefix.length, prefix);
+    framed.setRange(prefix.length, framed.length, payload);
+    return framed;
+  }
+
+  Future<Uint8List> _readExact(P2PStream stream, int length) async {
+    final out = BytesBuilder(copy: false);
+    while (out.length < length) {
+      final remaining = length - out.length;
+      final chunk = await stream.read(remaining);
+      if (chunk.isEmpty) {
+        throw const FormatException('DHT stream closed before frame payload');
+      }
+      if (chunk.length > remaining) {
+        out.add(Uint8List.sublistView(chunk, 0, remaining));
+      } else {
+        out.add(chunk);
+      }
+    }
+    return out.takeBytes();
+  }
+
   /// Sends a message to a peer without expecting a response (fire-and-forget).
   /// Used for ADD_PROVIDER per the libp2p Kademlia DHT spec.
   Future<void> sendMessageFireAndForget(PeerId peer, Message message) async {
@@ -257,7 +311,9 @@ class NetworkManager {
       throw DHTNetworkException('Cannot send message to self', peerId: peer);
     }
 
-    _logger.info('[$selfShortId] Sending fire-and-forget ${message.type} to $peerShortId');
+    _logger.info(
+      '[$selfShortId] Sending fire-and-forget ${message.type} to $peerShortId',
+    );
 
     try {
       final stream = await _createStream(peer);
@@ -265,11 +321,17 @@ class NetworkManager {
         final messageBytes = encodeMessage(message);
         await stream.write(messageBytes);
       } finally {
-        try { await stream.close(); } catch (_) {}
+        try {
+          await stream.close();
+        } catch (_) {}
       }
-      _logger.fine('[$selfShortId] Fire-and-forget ${message.type} sent to $peerShortId');
+      _logger.fine(
+        '[$selfShortId] Fire-and-forget ${message.type} sent to $peerShortId',
+      );
     } catch (e) {
-      _logger.warning('[$selfShortId] Fire-and-forget ${message.type} to $peerShortId failed: $e');
+      _logger.warning(
+        '[$selfShortId] Fire-and-forget ${message.type} to $peerShortId failed: $e',
+      );
       rethrow;
     }
   }
@@ -279,37 +341,39 @@ class NetworkManager {
     if (_closed) throw DHTClosedException();
     if (!_started) throw DHTNotStartedException();
   }
-  
+
   /// Gets the host instance
   Host get host => _host;
-  
+
   /// Checks if a peer is reachable
   Future<bool> isReachable(PeerId peer) async {
     _ensureStarted();
-    
+
     try {
       // Try to create a stream to the peer
       final stream = await _createStream(peer);
       await stream.close();
       return true;
     } catch (e) {
-      _logger.fine('Peer ${peer.toBase58().substring(0, 6)} is not reachable: $e');
+      _logger.fine(
+        'Peer ${peer.toBase58().substring(0, 6)} is not reachable: $e',
+      );
       return false;
     }
   }
-  
+
   /// Pings a peer to check connectivity
   Future<Duration?> ping(PeerId peer) async {
     _ensureStarted();
-    
+
     final stopwatch = Stopwatch()..start();
-    
+
     try {
       final pingMessage = Message(type: MessageType.ping);
       final response = await sendMessage(peer, pingMessage);
-      
+
       stopwatch.stop();
-      
+
       if (response.type == MessageType.ping) {
         return stopwatch.elapsed;
       } else {
@@ -324,7 +388,7 @@ class NetworkManager {
       return null;
     }
   }
-  
+
   @override
   String toString() => 'NetworkManager(${_host.id.toBase58().substring(0, 6)})';
-} 
+}

--- a/lib/src/dht/v2/managers/protocol_manager.dart
+++ b/lib/src/dht/v2/managers/protocol_manager.dart
@@ -9,7 +9,6 @@ import 'package:dart_libp2p/core/host/host.dart';
 import 'package:dart_libp2p/core/peer/peer_id.dart';
 import 'package:dart_libp2p/core/peer/addr_info.dart';
 import 'package:dart_libp2p/core/network/stream.dart';
-import 'package:dart_libp2p/core/network/context.dart';
 import 'package:dart_libp2p/core/multiaddr.dart';
 import 'package:logging/logging.dart';
 
@@ -25,7 +24,7 @@ import 'metrics_manager.dart';
 import 'routing_manager.dart';
 
 /// Manages protocol message handling for DHT v2
-/// 
+///
 /// This component handles:
 /// - Protocol message processing
 /// - Request/response handling
@@ -33,24 +32,24 @@ import 'routing_manager.dart';
 /// - Protocol-specific logic
 class ProtocolManager {
   static final Logger _logger = Logger('ProtocolManager');
-  
+
   final Host _host;
-  
+
   // Configuration
   DHTConfigV2? _config;
   MetricsManager? _metrics;
   RoutingManager? _routing;
   ProviderStore? _providerStore;
-  
+
   // State
   bool _started = false;
   bool _closed = false;
-  
+
   // Local datastore for records
   final Map<String, Record> _datastore = {};
-  
+
   ProtocolManager(this._host);
-  
+
   /// Initializes the protocol manager
   void initialize({
     required RoutingManager routing,
@@ -63,69 +62,81 @@ class ProtocolManager {
     _config = config;
     _metrics = metrics;
   }
-  
+
   /// Starts the protocol manager
   Future<void> start() async {
     if (_started || _closed) return;
-    
+
     _logger.info('Starting ProtocolManager...');
-    
+
     // Set up protocol handlers
     _setupProtocolHandlers();
-    
+
     _started = true;
     _logger.info('ProtocolManager started');
   }
-  
+
   /// Stops the protocol manager
   Future<void> close() async {
     if (_closed) return;
     _closed = true;
-    
+
     _logger.info('Closing ProtocolManager...');
-    
+
     // Remove protocol handlers
     _removeProtocolHandlers();
-    
+
     _logger.info('ProtocolManager closed');
   }
-  
+
   /// Sets up protocol handlers for incoming messages
   void _setupProtocolHandlers() {
-    _logger.info('Setting up protocol handlers for ${AminoConstants.protocolID}');
+    _logger.info(
+      'Setting up protocol handlers for ${AminoConstants.protocolID}',
+    );
     _host.setStreamHandler(AminoConstants.protocolID, _handleIncomingStream);
   }
-  
+
   /// Removes protocol handlers
   void _removeProtocolHandlers() {
     _logger.info('Removing protocol handlers');
     // Note: Host interface might not have removeStreamHandler method
     // This is typically handled by the host's cleanup during shutdown
   }
-  
+
   /// Handles incoming protocol streams
-  Future<void> _handleIncomingStream(P2PStream stream, PeerId remotePeer) async {
+  Future<void> _handleIncomingStream(
+    P2PStream stream,
+    PeerId remotePeer,
+  ) async {
     final remotePeerShortId = remotePeer.toBase58().substring(0, 6);
     final selfShortId = _host.id.toBase58().substring(0, 6);
-    
-    _logger.info('[$selfShortId] Handling incoming stream from $remotePeerShortId');
-    
+
+    _logger.info(
+      '[$selfShortId] Handling incoming stream from $remotePeerShortId',
+    );
+
     // Capture address (cheap, no I/O)
     MultiAddr? remoteAddr;
     try {
       remoteAddr = stream.conn.remoteMultiaddr;
     } catch (e) {
-      _logger.fine('[$selfShortId] Could not extract remote address for $remotePeerShortId: $e');
+      _logger.fine(
+        '[$selfShortId] Could not extract remote address for $remotePeerShortId: $e',
+      );
     }
 
     try {
-      // Read the message from the stream
-      final messageBytes = await stream.read();
+      // Read the full varint-length-prefixed protobuf frame. Network streams
+      // are chunked and may not return a complete DHT message in one read.
+      final messageBytes = await _readDhtFrame(stream);
 
       // Parse the protobuf message
       final message = decodeMessage(Uint8List.fromList(messageBytes));
 
-      _logger.fine('[$selfShortId] Received ${message.type} message from $remotePeerShortId');
+      _logger.fine(
+        '[$selfShortId] Received ${message.type} message from $remotePeerShortId',
+      );
 
       // Route the message to the appropriate handler
       final response = await _routeMessage(remotePeer, message);
@@ -136,18 +147,26 @@ class ProtocolManager {
         await stream.write(responseBytes);
         _logger.fine('[$selfShortId] Sent response to $remotePeerShortId');
       } else {
-        _logger.fine('[$selfShortId] ADD_PROVIDER handled (fire-and-forget, no response)');
+        _logger.fine(
+          '[$selfShortId] ADD_PROVIDER handled (fire-and-forget, no response)',
+        );
       }
 
       // Defer peerstore address storage to AFTER response is sent (non-blocking)
       if (remoteAddr != null) {
-        _host.peerStore.addOrUpdatePeer(remotePeer, addrs: [remoteAddr]).catchError((e) {
-          _logger.warning('[$selfShortId] Failed to store address for peer $remotePeerShortId: $e');
+        _host.peerStore
+            .addOrUpdatePeer(remotePeer, addrs: [remoteAddr]).catchError((e) {
+          _logger.warning(
+            '[$selfShortId] Failed to store address for peer $remotePeerShortId: $e',
+          );
         });
       }
-
     } catch (e, stackTrace) {
-      _logger.severe('[$selfShortId] Error handling stream from $remotePeerShortId: $e', e, stackTrace);
+      _logger.severe(
+        '[$selfShortId] Error handling stream from $remotePeerShortId: $e',
+        e,
+        stackTrace,
+      );
 
       // Send error response if possible
       try {
@@ -155,14 +174,60 @@ class ProtocolManager {
         final errorResponseBytes = encodeMessage(errorResponse);
         await stream.write(errorResponseBytes);
       } catch (responseError) {
-        _logger.warning('[$selfShortId] Failed to send error response: $responseError');
+        _logger.warning(
+          '[$selfShortId] Failed to send error response: $responseError',
+        );
       }
     } finally {
       // NOTE: Don't close the stream here!
       // The client (NetworkManager) will close it to avoid race conditions.
     }
   }
-  
+
+  Future<Uint8List> _readDhtFrame(P2PStream stream) async {
+    final prefix = <int>[];
+    var length = 0;
+    var shift = 0;
+    while (true) {
+      final chunk = await stream.read(1);
+      if (chunk.isEmpty) {
+        throw const FormatException('DHT stream closed before frame length');
+      }
+      final byte = chunk[0];
+      prefix.add(byte);
+      length |= (byte & 0x7f) << shift;
+      if (byte & 0x80 == 0) {
+        break;
+      }
+      shift += 7;
+      if (shift > 28) {
+        throw const FormatException('DHT frame length varint is too long');
+      }
+    }
+    final payload = await _readExact(stream, length);
+    final framed = Uint8List(prefix.length + payload.length);
+    framed.setRange(0, prefix.length, prefix);
+    framed.setRange(prefix.length, framed.length, payload);
+    return framed;
+  }
+
+  Future<Uint8List> _readExact(P2PStream stream, int length) async {
+    final out = BytesBuilder(copy: false);
+    while (out.length < length) {
+      final remaining = length - out.length;
+      final chunk = await stream.read(remaining);
+      if (chunk.isEmpty) {
+        throw const FormatException('DHT stream closed before frame payload');
+      }
+      if (chunk.length > remaining) {
+        out.add(Uint8List.sublistView(chunk, 0, remaining));
+      } else {
+        out.add(chunk);
+      }
+    }
+    return out.takeBytes();
+  }
+
   /// Routes a message to the appropriate handler
   Future<Message> _routeMessage(PeerId sender, Message message) async {
     switch (message.type) {
@@ -180,32 +245,43 @@ class ProtocolManager {
         return await handleAddProvider(sender, message);
       default:
         _logger.warning('Unknown message type: ${message.type}');
-        throw DHTProtocolException('Unknown message type: ${message.type}', peerId: sender);
+        throw DHTProtocolException(
+          'Unknown message type: ${message.type}',
+          peerId: sender,
+        );
     }
   }
-  
+
   /// Creates peer list with addresses populated from peerstore
   /// Uses parallel lookups for all peers to minimize latency
   Future<List<Peer>> _createPeerListWithAddresses(List<PeerId> peerIds) async {
     // Parallel peerstore lookups instead of sequential
-    final peerInfoFutures = peerIds.map((peerId) =>
-      _host.peerStore.getPeer(peerId).catchError((e) {
-        _logger.warning('Failed to get addresses for peer ${peerId.toBase58().substring(0, 6)}: $e');
-        return null;
-      })
-    ).toList();
+    final peerInfoFutures = peerIds
+        .map(
+          (peerId) => _host.peerStore.getPeer(peerId).catchError((e) {
+            _logger.warning(
+              'Failed to get addresses for peer ${peerId.toBase58().substring(0, 6)}: $e',
+            );
+            return null;
+          }),
+        )
+        .toList();
     final peerInfoResults = await Future.wait(peerInfoFutures);
 
     final result = <Peer>[];
     for (var i = 0; i < peerIds.length; i++) {
       final peerId = peerIds[i];
-      final addresses = peerInfoResults[i]?.addrs.map((addr) => addr.toBytes()).toList() ?? <Uint8List>[];
+      final addresses =
+          peerInfoResults[i]?.addrs.map((addr) => addr.toBytes()).toList() ??
+              <Uint8List>[];
 
-      result.add(Peer(
-        id: peerId.toBytes(),
-        addrs: addresses,
-        connection: ConnectionType.notConnected,
-      ));
+      result.add(
+        Peer(
+          id: peerId.toBytes(),
+          addrs: addresses,
+          connection: ConnectionType.notConnected,
+        ),
+      );
     }
 
     return result;
@@ -220,11 +296,18 @@ class ProtocolManager {
 
     try {
       if (message.key == null) {
-        throw DHTProtocolException('FIND_NODE message missing key', peerId: sender);
+        throw DHTProtocolException(
+          'FIND_NODE message missing key',
+          peerId: sender,
+        );
       }
 
       // Find closest peers
-      final closestPeers = await _routing?.getNearestPeers(message.key!, _config?.bucketSize ?? 20) ?? [];
+      final closestPeers = await _routing?.getNearestPeers(
+            message.key!,
+            _config?.bucketSize ?? 20,
+          ) ??
+          [];
 
       // Create response (parallel peerstore lookups inside)
       final response = Message(
@@ -233,21 +316,31 @@ class ProtocolManager {
         closerPeers: await _createPeerListWithAddresses(closestPeers),
       );
 
-      _logger.fine('Responding to FIND_NODE with ${response.closerPeers.length} peers');
+      _logger.fine(
+        'Responding to FIND_NODE with ${response.closerPeers.length} peers',
+      );
 
       // Defer sender RT insertion (non-blocking)
-      _routing?.addPeer(sender, queryPeer: true, isReplaceable: true).catchError((e) {
-        _logger.warning('Deferred RT insertion failed for $senderShortId: $e');
+      _routing
+          ?.addPeer(sender, queryPeer: true, isReplaceable: true)
+          .catchError((e) {
+        _logger.warning(
+          'Deferred RT insertion failed for $senderShortId: $e',
+        );
         return false;
       });
 
       return response;
     } catch (e) {
       _logger.warning('Error handling FIND_NODE: $e');
-      throw DHTProtocolException('Failed to handle FIND_NODE: $e', peerId: sender, cause: e);
+      throw DHTProtocolException(
+        'Failed to handle FIND_NODE: $e',
+        peerId: sender,
+        cause: e,
+      );
     }
   }
-  
+
   /// Handles a GET_VALUE message
   Future<Message> handleGetValue(PeerId sender, Message message) async {
     _ensureStarted();
@@ -257,7 +350,10 @@ class ProtocolManager {
 
     try {
       if (message.key == null) {
-        throw DHTProtocolException('GET_VALUE message missing key', peerId: sender);
+        throw DHTProtocolException(
+          'GET_VALUE message missing key',
+          peerId: sender,
+        );
       }
 
       // Check local datastore for the record
@@ -265,7 +361,11 @@ class ProtocolManager {
       final localRecord = _datastore[keyString];
 
       // Get closer peers from routing table (parallel peerstore lookups inside)
-      final closestPeers = await _routing?.getNearestPeers(message.key!, _config?.bucketSize ?? 20) ?? [];
+      final closestPeers = await _routing?.getNearestPeers(
+            message.key!,
+            _config?.bucketSize ?? 20,
+          ) ??
+          [];
       final closerPeers = await _createPeerListWithAddresses(closestPeers);
 
       final response = Message(
@@ -276,24 +376,36 @@ class ProtocolManager {
       );
 
       if (localRecord != null) {
-        _logger.fine('Responding to GET_VALUE with record and ${closerPeers.length} closer peers');
+        _logger.fine(
+          'Responding to GET_VALUE with record and ${closerPeers.length} closer peers',
+        );
       } else {
-        _logger.fine('Responding to GET_VALUE with ${closerPeers.length} closer peers (no local record)');
+        _logger.fine(
+          'Responding to GET_VALUE with ${closerPeers.length} closer peers (no local record)',
+        );
       }
 
       // Defer sender RT insertion (non-blocking)
-      _routing?.addPeer(sender, queryPeer: true, isReplaceable: true).catchError((e) {
-        _logger.warning('Deferred RT insertion failed for $senderShortId: $e');
+      _routing
+          ?.addPeer(sender, queryPeer: true, isReplaceable: true)
+          .catchError((e) {
+        _logger.warning(
+          'Deferred RT insertion failed for $senderShortId: $e',
+        );
         return false;
       });
 
       return response;
     } catch (e) {
       _logger.warning('Error handling GET_VALUE: $e');
-      throw DHTProtocolException('Failed to handle GET_VALUE: $e', peerId: sender, cause: e);
+      throw DHTProtocolException(
+        'Failed to handle GET_VALUE: $e',
+        peerId: sender,
+        cause: e,
+      );
     }
   }
-  
+
   /// Handles a PUT_VALUE message
   Future<Message> handlePutValue(PeerId sender, Message message) async {
     _ensureStarted();
@@ -303,55 +415,73 @@ class ProtocolManager {
 
     try {
       if (message.key == null || message.record == null) {
-        throw DHTProtocolException('PUT_VALUE message missing key or record', peerId: sender);
+        throw DHTProtocolException(
+          'PUT_VALUE message missing key or record',
+          peerId: sender,
+        );
       }
-      
+
       // Validate the record signature
       final record = message.record!;
       final keyString = String.fromCharCodes(message.key!);
-      
-      _logger.fine('Validating record signature for key: ${keyString.substring(0, 10)}...');
-      
+
+      _logger.fine(
+        'Validating record signature for key: ${keyString.substring(0, 10)}...',
+      );
+
       final isValid = await RecordSigner.validateRecordSignature(record);
       if (!isValid) {
-        _logger.warning('Invalid record signature from $senderShortId for key: ${keyString.substring(0, 10)}...');
+        _logger.warning(
+          'Invalid record signature from $senderShortId for key: ${keyString.substring(0, 10)}...',
+        );
         throw DHTProtocolException('Invalid record signature', peerId: sender);
       }
-      
+
       // Check if this is a newer record than what we have
       final existingRecord = _datastore[keyString];
       if (existingRecord != null) {
         if (record.timeReceived <= existingRecord.timeReceived) {
-          _logger.fine('Rejecting older record from $senderShortId for key: ${keyString.substring(0, 10)}...');
+          _logger.fine(
+            'Rejecting older record from $senderShortId for key: ${keyString.substring(0, 10)}...',
+          );
           // Still return success - we just don't store the older record
         } else {
-          _logger.fine('Accepting newer record from $senderShortId for key: ${keyString.substring(0, 10)}...');
+          _logger.fine(
+            'Accepting newer record from $senderShortId for key: ${keyString.substring(0, 10)}...',
+          );
           _datastore[keyString] = record;
         }
       } else {
-        _logger.fine('Storing new record from $senderShortId for key: ${keyString.substring(0, 10)}...');
+        _logger.fine(
+          'Storing new record from $senderShortId for key: ${keyString.substring(0, 10)}...',
+        );
         _datastore[keyString] = record;
       }
-      
+
       // Create response
-      final response = Message(
-        type: MessageType.putValue,
-        key: message.key,
-      );
+      final response = Message(type: MessageType.putValue, key: message.key);
 
       // Defer sender RT insertion (non-blocking)
-      _routing?.addPeer(sender, queryPeer: true, isReplaceable: true).catchError((e) {
-        _logger.warning('Deferred RT insertion failed for $senderShortId: $e');
+      _routing
+          ?.addPeer(sender, queryPeer: true, isReplaceable: true)
+          .catchError((e) {
+        _logger.warning(
+          'Deferred RT insertion failed for $senderShortId: $e',
+        );
         return false;
       });
 
       return response;
     } catch (e) {
       _logger.warning('Error handling PUT_VALUE: $e');
-      throw DHTProtocolException('Failed to handle PUT_VALUE: $e', peerId: sender, cause: e);
+      throw DHTProtocolException(
+        'Failed to handle PUT_VALUE: $e',
+        peerId: sender,
+        cause: e,
+      );
     }
   }
-  
+
   /// Handles a GET_PROVIDERS message
   Future<Message> handleGetProviders(PeerId sender, Message message) async {
     _ensureStarted();
@@ -361,46 +491,67 @@ class ProtocolManager {
 
     try {
       if (message.key == null) {
-        throw DHTProtocolException('GET_PROVIDERS message missing key', peerId: sender);
+        throw DHTProtocolException(
+          'GET_PROVIDERS message missing key',
+          peerId: sender,
+        );
       }
-      
+
       // Get providers from local provider store
       final cid = CID.fromBytes(message.key!);
       final providers = await _providerStore?.getProviders(cid) ?? [];
-      
+
       // Convert providers to protocol format
-      final providerPeers = providers.map((provider) => Peer(
-        id: provider.id.toBytes(),
-        addrs: provider.addrs.map((addr) => addr.toBytes()).toList(),
-        connection: ConnectionType.notConnected,
-      )).toList();
-      
+      final providerPeers = providers
+          .map(
+            (provider) => Peer(
+              id: provider.id.toBytes(),
+              addrs: provider.addrs.map((addr) => addr.toBytes()).toList(),
+              connection: ConnectionType.notConnected,
+            ),
+          )
+          .toList();
+
       // Get closer peers from routing table
-      final closestPeers = await _routing?.getNearestPeers(message.key!, _config?.bucketSize ?? 20) ?? [];
+      final closestPeers = await _routing?.getNearestPeers(
+            message.key!,
+            _config?.bucketSize ?? 20,
+          ) ??
+          [];
       final closerPeers = await _createPeerListWithAddresses(closestPeers);
-      
+
       final response = Message(
         type: MessageType.getProviders,
         key: message.key,
         providerPeers: providerPeers,
         closerPeers: closerPeers,
       );
-      
-      _logger.fine('Responding to GET_PROVIDERS with ${providerPeers.length} providers and ${closerPeers.length} closer peers');
+
+      _logger.fine(
+        'Responding to GET_PROVIDERS with ${providerPeers.length} providers and ${closerPeers.length} closer peers',
+      );
 
       // Defer sender RT insertion (non-blocking)
-      _routing?.addPeer(sender, queryPeer: true, isReplaceable: true).catchError((e) {
-        _logger.warning('Deferred RT insertion failed for $senderShortId: $e');
+      _routing
+          ?.addPeer(sender, queryPeer: true, isReplaceable: true)
+          .catchError((e) {
+        _logger.warning(
+          'Deferred RT insertion failed for $senderShortId: $e',
+        );
         return false;
       });
 
       return response;
     } catch (e) {
       _logger.warning('Error handling GET_PROVIDERS: $e');
-      throw DHTProtocolException('Failed to handle GET_PROVIDERS: $e', peerId: sender, cause: e);
+      throw DHTProtocolException(
+        'Failed to handle GET_PROVIDERS: $e',
+        peerId: sender,
+        cause: e,
+      );
     }
   }
-  
+
   /// Handles an ADD_PROVIDER message
   Future<Message> handleAddProvider(PeerId sender, Message message) async {
     _ensureStarted();
@@ -410,49 +561,63 @@ class ProtocolManager {
 
     try {
       if (message.key == null || message.providerPeers.isEmpty) {
-        throw DHTProtocolException('ADD_PROVIDER message missing key or providers', peerId: sender);
+        throw DHTProtocolException(
+          'ADD_PROVIDER message missing key or providers',
+          peerId: sender,
+        );
       }
-      
+
       // Store providers in local provider store
       final cid = CID.fromBytes(message.key!);
       var storedCount = 0;
-      
+
       for (final providerPeer in message.providerPeers) {
         try {
           final providerId = PeerId.fromBytes(providerPeer.id);
-          final providerAddrs = providerPeer.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList();
+          final providerAddrs = providerPeer.addrs
+              .map((addr) => MultiAddr.fromBytes(addr))
+              .toList();
           final providerInfo = AddrInfo(providerId, providerAddrs);
-          
+
           await _providerStore?.addProvider(cid, providerInfo);
           storedCount++;
-          
-          _logger.fine('Stored provider ${providerId.toBase58().substring(0, 6)} for key');
+
+          _logger.fine(
+            'Stored provider ${providerId.toBase58().substring(0, 6)} for key',
+          );
         } catch (e) {
           _logger.warning('Failed to store provider: $e');
         }
       }
-      
-      _logger.fine('Stored $storedCount/${message.providerPeers.length} providers');
 
-      // Create response
-      final response = Message(
-        type: MessageType.addProvider,
-        key: message.key,
+      _logger.fine(
+        'Stored $storedCount/${message.providerPeers.length} providers',
       );
 
+      // Create response
+      final response = Message(type: MessageType.addProvider, key: message.key);
+
       // Defer sender RT insertion (non-blocking)
-      _routing?.addPeer(sender, queryPeer: true, isReplaceable: true).catchError((e) {
-        _logger.warning('Deferred RT insertion failed for $senderShortId: $e');
+      _routing
+          ?.addPeer(sender, queryPeer: true, isReplaceable: true)
+          .catchError((e) {
+        _logger.warning(
+          'Deferred RT insertion failed for $senderShortId: $e',
+        );
         return false;
       });
 
       return response;
     } catch (e) {
       _logger.warning('Error handling ADD_PROVIDER: $e');
-      throw DHTProtocolException('Failed to handle ADD_PROVIDER: $e', peerId: sender, cause: e);
+      throw DHTProtocolException(
+        'Failed to handle ADD_PROVIDER: $e',
+        peerId: sender,
+        cause: e,
+      );
     }
   }
-  
+
   /// Handles a PING message
   Future<Message> handlePing(PeerId sender, Message message) async {
     _ensureStarted();
@@ -461,16 +626,18 @@ class ProtocolManager {
     _logger.fine('Handling PING from $senderShortId');
 
     // Defer RT insertion (non-blocking) — respond to ping as fast as possible
-    _routing?.addPeer(sender, queryPeer: true, isReplaceable: true).catchError((e) {
+    _routing?.addPeer(sender, queryPeer: true, isReplaceable: true).catchError((
+      e,
+    ) {
       _logger.warning('Deferred RT insertion failed for $senderShortId: $e');
       return false;
     });
 
     return Message(type: MessageType.ping);
   }
-  
+
   // Public datastore interface methods
-  
+
   /// Gets a record from the local datastore
   Future<Record?> getRecordFromDatastore(String key) async {
     _ensureStarted();
@@ -482,23 +649,23 @@ class ProtocolManager {
     }
     return record;
   }
-  
+
   /// Gets a record from the local datastore using byte key
   Future<Record?> getRecordFromDatastoreBytes(Uint8List keyBytes) async {
     final keyString = utf8.decode(keyBytes);
     return await getRecordFromDatastore(keyString);
   }
-  
+
   /// Puts a record into the local datastore
   Future<void> putRecordToDatastore(String key, Record record) async {
     _ensureStarted();
-    
+
     // Validate the record signature before storing
     final isValid = await RecordSigner.validateRecordSignature(record);
     if (!isValid) {
       throw DHTProtocolException('Cannot store record with invalid signature');
     }
-    
+
     // Check if this is a newer record than what we have
     final existingRecord = _datastore[key];
     if (existingRecord != null) {
@@ -507,29 +674,31 @@ class ProtocolManager {
         return; // Don't store older records
       }
     }
-    
+
     _datastore[key] = record;
     // Use existing metrics method
     _metrics?.recordQuerySuccess(Duration.zero);
     _logger.fine('Stored record in datastore for key: ${key}...');
   }
-  
+
   /// Puts a record into the local datastore using dynamic record
   Future<void> putRecordToDatastoreDynamic(dynamic record) async {
     if (record is! Record) {
-      throw DHTProtocolException('Invalid record type: expected Record, got ${record.runtimeType}');
+      throw DHTProtocolException(
+        'Invalid record type: expected Record, got ${record.runtimeType}',
+      );
     }
-    
+
     // Extract key from record - this assumes the record has a key field
     // In a real implementation, you'd need to determine the key from the record
     final keyString = String.fromCharCodes(record.key ?? Uint8List(0));
     if (keyString.isEmpty) {
       throw DHTProtocolException('Record missing key field');
     }
-    
+
     await putRecordToDatastore(keyString, record as Record);
   }
-  
+
   /// Checks if a record exists in the local datastore
   Future<bool> hasRecordInDatastore(String key) async {
     _ensureStarted();
@@ -537,7 +706,7 @@ class ProtocolManager {
     _logger.fine('Datastore contains key ${key}...: $hasRecord');
     return hasRecord;
   }
-  
+
   /// Removes a record from the local datastore
   Future<void> removeRecordFromDatastore(String key) async {
     _ensureStarted();
@@ -548,23 +717,23 @@ class ProtocolManager {
       _logger.fine('Removed record from datastore for key: ${key}...');
     }
   }
-  
+
   /// Gets all keys from the local datastore
   Stream<String> getKeysFromDatastore() async* {
     _ensureStarted();
     _logger.fine('Getting all keys from datastore (${_datastore.length} keys)');
-    
+
     for (final key in _datastore.keys) {
       yield key;
     }
   }
-  
+
   /// Gets the current size of the local datastore
   Future<int> getDatastoreSize() async {
     _ensureStarted();
     return _datastore.length;
   }
-  
+
   /// Clears all records from the local datastore
   Future<void> clearDatastore() async {
     _ensureStarted();
@@ -572,27 +741,39 @@ class ProtocolManager {
     _datastore.clear();
     _logger.info('Cleared datastore (removed $count records)');
   }
-  
+
   /// Gets datastore statistics
   Future<Map<String, dynamic>> getDatastoreStatistics() async {
     _ensureStarted();
-    
+
     final stats = <String, dynamic>{
       'total_records': _datastore.length,
-      'total_size_bytes': _datastore.values.fold<int>(0, (sum, record) => sum + record.value.length),
-      'oldest_record_timestamp': _datastore.values.isEmpty ? null : _datastore.values.map((r) => r.timeReceived).reduce((a, b) => a < b ? a : b),
-      'newest_record_timestamp': _datastore.values.isEmpty ? null : _datastore.values.map((r) => r.timeReceived).reduce((a, b) => a > b ? a : b),
+      'total_size_bytes': _datastore.values.fold<int>(
+        0,
+        (sum, record) => sum + record.value.length,
+      ),
+      'oldest_record_timestamp': _datastore.values.isEmpty
+          ? null
+          : _datastore.values
+              .map((r) => r.timeReceived)
+              .reduce((a, b) => a < b ? a : b),
+      'newest_record_timestamp': _datastore.values.isEmpty
+          ? null
+          : _datastore.values
+              .map((r) => r.timeReceived)
+              .reduce((a, b) => a > b ? a : b),
     };
-    
+
     return stats;
   }
-  
+
   /// Ensures the protocol manager is started
   void _ensureStarted() {
     if (_closed) throw DHTClosedException();
     if (!_started) throw DHTNotStartedException();
   }
-  
+
   @override
-  String toString() => 'ProtocolManager(${_host.id.toBase58().substring(0, 6)})';
-} 
+  String toString() =>
+      'ProtocolManager(${_host.id.toBase58().substring(0, 6)})';
+}

--- a/lib/src/dht/v2/managers/query_manager.dart
+++ b/lib/src/dht/v2/managers/query_manager.dart
@@ -30,7 +30,7 @@ class LookupWithFollowupResult {
   final List<PeerId> peers;
   final LookupTerminationReason terminationReason;
   final List<dynamic> errors;
-  
+
   const LookupWithFollowupResult({
     required this.peers,
     required this.terminationReason,
@@ -46,7 +46,7 @@ enum LookupTerminationReason {
 }
 
 /// Manages query operations for DHT v2
-/// 
+///
 /// This component handles:
 /// - Peer lookups
 /// - Value operations
@@ -55,7 +55,7 @@ enum LookupTerminationReason {
 /// - Query coordination
 class QueryManager {
   static final Logger _logger = Logger('QueryManager');
-  
+
   // Dependencies
   NetworkManager? _network;
   RoutingManager? _routing;
@@ -63,13 +63,13 @@ class QueryManager {
   DHTConfigV2? _config;
   MetricsManager? _metrics;
   ProviderStore? _providerStore;
-  
+
   // State
   bool _started = false;
   bool _closed = false;
-  
+
   QueryManager();
-  
+
   /// Initializes the query manager
   void initialize({
     required NetworkManager network,
@@ -86,35 +86,35 @@ class QueryManager {
     _metrics = metrics;
     _providerStore = providerStore;
   }
-  
+
   /// Starts the query manager
   Future<void> start() async {
     if (_started || _closed) return;
-    
+
     _logger.info('Starting QueryManager...');
     _started = true;
     _logger.info('QueryManager started');
   }
-  
+
   /// Stops the query manager
   Future<void> close() async {
     if (_closed) return;
     _closed = true;
-    
+
     _logger.info('Closing QueryManager...');
     _logger.info('QueryManager closed');
   }
-  
+
   /// Finds a peer by ID
   Future<AddrInfo?> findPeer(PeerId id, {RoutingOptions? options}) async {
     _ensureStarted();
-    
+
     final stopwatch = Stopwatch()..start();
     _metrics?.recordQueryStart();
-    
+
     try {
       _logger.info('Finding peer ${id.toBase58().substring(0, 6)}...');
-      
+
       // Check routing table first
       final existingPeer = await _routing?.findPeer(id);
       if (existingPeer != null) {
@@ -124,45 +124,54 @@ class QueryManager {
           // Peer has addresses in peerstore - return them immediately
           stopwatch.stop();
           _metrics?.recordQuerySuccess(stopwatch.elapsed);
-          _logger.fine('Found peer ${id.toBase58().substring(0, 6)} with ${peerInfo.addrs.length} peerstore addresses');
+          _logger.fine(
+              'Found peer ${id.toBase58().substring(0, 6)} with ${peerInfo.addrs.length} peerstore addresses');
           return AddrInfo(id, peerInfo.addrs.toList());
         } else {
           // CRITICAL FIX: Peer exists in routing table but no addresses
           // Proceed with network query to discover addresses
-          _logger.fine('Peer ${id.toBase58().substring(0, 6)} in routing table but no addresses - performing network query for address discovery');
+          _logger.fine(
+              'Peer ${id.toBase58().substring(0, 6)} in routing table but no addresses - performing network query for address discovery');
         }
       } else {
-        _logger.fine('Peer ${id.toBase58().substring(0, 6)} not in routing table - performing network query');
+        _logger.fine(
+            'Peer ${id.toBase58().substring(0, 6)} not in routing table - performing network query');
       }
-      
+
       // Perform network query to discover addresses (for both routing table peers without addresses AND unknown peers)
-      final result = await _performNetworkQuery(id, QueryType.findPeer, options);
-      
+      final result =
+          await _performNetworkQuery(id, QueryType.findPeer, options);
+
       stopwatch.stop();
       _metrics?.recordQuerySuccess(stopwatch.elapsed);
       return result;
     } catch (e) {
       stopwatch.stop();
       _metrics?.recordQueryFailure('find_peer', peer: id);
-      _logger.warning('Failed to find peer ${id.toBase58().substring(0, 6)}: $e');
+      _logger
+          .warning('Failed to find peer ${id.toBase58().substring(0, 6)}: $e');
       return null;
     }
   }
-  
+
   /// Gets closest peers to a target
-  Future<List<AddrInfo>> getClosestPeers(PeerId target, {bool networkQueryEnabled = true}) async {
+  Future<List<AddrInfo>> getClosestPeers(PeerId target,
+      {bool networkQueryEnabled = true}) async {
     _ensureStarted();
-    
+
     final stopwatch = Stopwatch()..start();
     _metrics?.recordQueryStart();
-    
+
     try {
-      _logger.info('Getting closest peers to ${target.toBase58().substring(0, 6)}...');
-      
+      _logger.info(
+          'Getting closest peers to ${target.toBase58().substring(0, 6)}...');
+
       // Get peers from routing table
       final targetBytes = target.toBytes();
-      final closestPeers = await _routing?.getNearestPeers(targetBytes, _config?.bucketSize ?? 20) ?? [];
-      
+      final closestPeers = await _routing?.getNearestPeers(
+              targetBytes, _config?.bucketSize ?? 20) ??
+          [];
+
       // Convert to AddrInfo - CRITICAL FIX: Return all routing table peers, even without peerstore addresses
       final result = <AddrInfo>[];
       for (final peerId in closestPeers) {
@@ -171,19 +180,23 @@ class QueryManager {
         if (peerInfo != null && peerInfo.addrs.isNotEmpty) {
           // Peer has addresses in peerstore - use them
           result.add(AddrInfo(peerId, peerInfo.addrs.toList()));
-          _logger.finest('Added peer ${peerId.toBase58().substring(0, 6)} with ${peerInfo.addrs.length} peerstore addresses');
+          _logger.finest(
+              'Added peer ${peerId.toBase58().substring(0, 6)} with ${peerInfo.addrs.length} peerstore addresses');
         } else {
           // CRITICAL FIX: Peer is in routing table but not peerstore - still return it!
           // Network maintenance can attempt connection and discover addresses
-          result.add(AddrInfo(peerId, [])); // Empty addresses - will be discovered during connection
-          _logger.finest('Added peer ${peerId.toBase58().substring(0, 6)} with empty addresses (routing table only)');
+          result.add(AddrInfo(peerId,
+              [])); // Empty addresses - will be discovered during connection
+          _logger.finest(
+              'Added peer ${peerId.toBase58().substring(0, 6)} with empty addresses (routing table only)');
         }
       }
-      
+
       stopwatch.stop();
       _metrics?.recordQuerySuccess(stopwatch.elapsed);
-      
-      _logger.info('Found ${result.length} closest peers (${closestPeers.length} from routing table)');
+
+      _logger.info(
+          'Found ${result.length} closest peers (${closestPeers.length} from routing table)');
       return result;
     } catch (e) {
       stopwatch.stop();
@@ -192,119 +205,133 @@ class QueryManager {
       return [];
     }
   }
-  
+
   /// Finds providers for a CID
   Stream<AddrInfo> findProvidersAsync(CID cid, int count) async* {
     _ensureStarted();
-    
-    _logger.info('Finding providers for CID ${cid.toString().substring(0, 10)}...');
-    
+
+    _logger.info(
+        'Finding providers for CID ${cid.toString().substring(0, 10)}...');
+
     final stopwatch = Stopwatch()..start();
     _metrics?.recordQueryStart();
-    
+
     try {
-      final cidBytes = cid.toBytes();
+      final cidBytes = cid.multihash;
       final controller = StreamController<AddrInfo>();
       final foundProviders = <PeerId>{};
-      
+
       // Start the provider search asynchronously
       _findProvidersAsync(cidBytes, count, controller, foundProviders);
-      
+
       yield* controller.stream;
-      
+
       stopwatch.stop();
       _metrics?.recordQuerySuccess(stopwatch.elapsed);
-      
-      _logger.info('Provider search completed for CID ${cid.toString().substring(0, 10)}. Found ${foundProviders.length} providers');
+
+      _logger.info(
+          'Provider search completed for CID ${cid.toString().substring(0, 10)}. Found ${foundProviders.length} providers');
     } catch (e) {
       stopwatch.stop();
       _metrics?.recordQueryFailure('find_providers');
-      _logger.warning('Failed to find providers for CID ${cid.toString().substring(0, 10)}: $e');
+      _logger.warning(
+          'Failed to find providers for CID ${cid.toString().substring(0, 10)}: $e');
       rethrow;
     }
   }
-  
+
   /// Gets a value from the DHT
   Future<Uint8List?> getValue(String key, RoutingOptions? options) async {
     _ensureStarted();
-    
+
     final stopwatch = Stopwatch()..start();
     _metrics?.recordQueryStart();
-    
+
     try {
       _logger.info('Getting value for key: ${key.substring(0, 10)}...');
-      
+
       final keyBytes = Uint8List.fromList(key.codeUnits);
       final foundRecords = <Record>[];
-      
+
       // Check local datastore first
       _logger.fine('Checking local datastore for key');
       final localRecord = await _protocol?.getRecordFromDatastore(key);
       if (localRecord != null) {
         stopwatch.stop();
         _metrics?.recordQuerySuccess(stopwatch.elapsed);
-        _logger.info('Found value in local datastore for key: ${key.substring(0, 10)}');
+        _logger.info(
+            'Found value in local datastore for key: ${key.substring(0, 10)}');
         return localRecord.value;
       }
-      
+
       // Perform distributed lookup for the value
       // ignore: unused_local_variable - result not used; records collected via queryFn
       final result = await runLookupWithFollowup(
         target: keyBytes,
         queryFn: (peer) async {
-          _logger.fine('Sending GET_VALUE to ${peer.toBase58().substring(0, 6)}');
-          
+          _logger
+              .fine('Sending GET_VALUE to ${peer.toBase58().substring(0, 6)}');
+
           final message = Message(
             type: MessageType.getValue,
             key: keyBytes,
           );
-          
+
           final response = await _network?.sendMessage(peer, message);
           if (response == null) {
             throw DHTNetworkException('No response from peer', peerId: peer);
           }
-          
+
           // If we found a record, validate and collect it
           if (response.record != null) {
             try {
               // Validate the record signature
-              final isValid = await RecordSigner.validateRecordSignature(response.record!);
+              final isValid =
+                  await RecordSigner.validateRecordSignature(response.record!);
               if (isValid) {
                 foundRecords.add(response.record!);
-                _logger.fine('Found and validated record from ${peer.toBase58().substring(0, 6)}');
+                _logger.fine(
+                    'Found and validated record from ${peer.toBase58().substring(0, 6)}');
               } else {
-                _logger.warning('Invalid record signature from ${peer.toBase58().substring(0, 6)}');
+                _logger.warning(
+                    'Invalid record signature from ${peer.toBase58().substring(0, 6)}');
               }
             } catch (e) {
-              _logger.warning('Error validating record from ${peer.toBase58().substring(0, 6)}: $e');
+              _logger.warning(
+                  'Error validating record from ${peer.toBase58().substring(0, 6)}: $e');
             }
           }
-          
+
           // Return closer peers for continued lookup
-          return response.closerPeers.map((p) => AddrInfo(
-            PeerId.fromBytes(p.id),
-            p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-          )).toList();
+          return response.closerPeers
+              .map((p) => AddrInfo(
+                    PeerId.fromBytes(p.id),
+                    p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                  ))
+              .toList();
         },
         stopFn: (peerset) {
           // Stop when we've queried enough peers or found valid records
-          return foundRecords.isNotEmpty || 
-                 peerset.getClosestInStates([PeerState.queried]).length >= (_config?.resiliency ?? 3);
+          return foundRecords.isNotEmpty ||
+              peerset.getClosestInStates([PeerState.queried]).length >=
+                  (_config?.resiliency ?? 3);
         },
       );
-      
+
       stopwatch.stop();
       _metrics?.recordQuerySuccess(stopwatch.elapsed);
-      
+
       if (foundRecords.isNotEmpty) {
         // Select the most recent valid record
         foundRecords.sort((a, b) => b.timeReceived.compareTo(a.timeReceived));
         final bestRecord = foundRecords.first;
-        
-        _logger.info('Get value completed for key: ${key.substring(0, 10)} - found ${foundRecords.length} valid records');
+
+        _logger.info(
+            'Get value completed for key: ${key.substring(0, 10)} - found ${foundRecords.length} valid records');
         return bestRecord.value;
       } else {
-        _logger.info('Get value completed for key: ${key.substring(0, 10)} - no valid records found');
+        _logger.info(
+            'Get value completed for key: ${key.substring(0, 10)} - no valid records found');
         return null;
       }
     } catch (e) {
@@ -314,68 +341,76 @@ class QueryManager {
       return null;
     }
   }
-  
+
   /// Puts a value in the DHT
-  Future<void> putValue(String key, Uint8List value, RoutingOptions? options) async {
+  Future<void> putValue(
+      String key, Uint8List value, RoutingOptions? options) async {
     _ensureStarted();
-    
+
     final stopwatch = Stopwatch()..start();
     _metrics?.recordQueryStart();
-    
+
     try {
       _logger.info('Putting value for key: ${key.substring(0, 10)}...');
-      
+
       final keyBytes = Uint8List.fromList(key.codeUnits);
-      
+
       // Create a properly signed record
-      final hostPrivateKey = await _network?.host.peerStore.keyBook.privKey(_network!.host.id);
+      final hostPrivateKey =
+          await _network?.host.peerStore.keyBook.privKey(_network!.host.id);
       if (hostPrivateKey == null) {
-        throw DHTNetworkException('Cannot sign record: host private key not available');
+        throw DHTNetworkException(
+            'Cannot sign record: host private key not available');
       }
-      
+
       final signedRecord = await RecordSigner.createSignedRecord(
         key: key,
         value: value,
         privateKey: hostPrivateKey,
         peerId: _network!.host.id,
       );
-      
-      _logger.fine('Created signed record for key: ${key.substring(0, 10)}... (${signedRecord.signature.length} bytes signature)');
-      
+
+      _logger.fine(
+          'Created signed record for key: ${key.substring(0, 10)}... (${signedRecord.signature.length} bytes signature)');
+
       // Store locally first
       await _protocol?.putRecordToDatastore(key, signedRecord);
       _logger.fine('Stored record locally for key: ${key.substring(0, 10)}...');
-      
+
       // Find closest peers to store the value
       final result = await runLookupWithFollowup(
         target: keyBytes,
         queryFn: (peer) async {
-          _logger.fine('Sending FIND_NODE to ${peer.toBase58().substring(0, 6)} for put operation');
-          
+          _logger.fine(
+              'Sending FIND_NODE to ${peer.toBase58().substring(0, 6)} for put operation');
+
           final message = Message(
             type: MessageType.findNode,
             key: keyBytes,
           );
-          
+
           final response = await _network?.sendMessage(peer, message);
           if (response == null) {
             throw DHTNetworkException('No response from peer', peerId: peer);
           }
-          
-          return response.closerPeers.map((p) => AddrInfo(
-            PeerId.fromBytes(p.id),
-            p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-          )).toList();
+
+          return response.closerPeers
+              .map((p) => AddrInfo(
+                    PeerId.fromBytes(p.id),
+                    p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                  ))
+              .toList();
         },
         stopFn: (peerset) {
-          return peerset.getClosestInStates([PeerState.queried]).length >= (_config?.resiliency ?? 3);
+          return peerset.getClosestInStates([PeerState.queried]).length >=
+              (_config?.resiliency ?? 3);
         },
       );
-      
+
       // Send PUT_VALUE to closest peers with the signed record
       final closestPeers = result.peers.take(_config?.resiliency ?? 3);
       var successCount = 0;
-      
+
       for (final peer in closestPeers) {
         try {
           final putMessage = Message(
@@ -383,19 +418,22 @@ class QueryManager {
             key: keyBytes,
             record: signedRecord,
           );
-          
+
           await _network?.sendMessage(peer, putMessage);
           successCount++;
-          _logger.fine('Successfully sent signed record to ${peer.toBase58().substring(0, 6)}');
+          _logger.fine(
+              'Successfully sent signed record to ${peer.toBase58().substring(0, 6)}');
         } catch (e) {
-          _logger.warning('Failed to send signed record to ${peer.toBase58().substring(0, 6)}: $e');
+          _logger.warning(
+              'Failed to send signed record to ${peer.toBase58().substring(0, 6)}: $e');
         }
       }
-      
+
       stopwatch.stop();
       _metrics?.recordQuerySuccess(stopwatch.elapsed);
-      
-      _logger.info('Put value completed for key: ${key.substring(0, 10)} - successfully stored to $successCount/${closestPeers.length} peers');
+
+      _logger.info(
+          'Put value completed for key: ${key.substring(0, 10)} - successfully stored to $successCount/${closestPeers.length} peers');
     } catch (e) {
       stopwatch.stop();
       _metrics?.recordQueryFailure('put_value');
@@ -403,69 +441,76 @@ class QueryManager {
       rethrow;
     }
   }
-  
+
   /// Searches for values in the DHT
   Stream<Uint8List> searchValue(String key, RoutingOptions? options) async* {
     _ensureStarted();
-    
+
     _logger.info('Searching for values for key: ${key.substring(0, 10)}...');
-    
+
     final keyBytes = Uint8List.fromList(key.codeUnits);
     final controller = StreamController<Uint8List>();
-    
+
     // Run the search asynchronously
     _searchValueAsync(key, keyBytes, options, controller);
-    
+
     yield* controller.stream;
   }
-  
+
   /// Asynchronously searches for values
-  Future<void> _searchValueAsync(String key, Uint8List keyBytes, RoutingOptions? options, StreamController<Uint8List> controller) async {
+  Future<void> _searchValueAsync(String key, Uint8List keyBytes,
+      RoutingOptions? options, StreamController<Uint8List> controller) async {
     try {
       // Check local datastore first
       _logger.fine('Checking local datastore for key');
-      
+
       // Perform distributed search
       await runLookupWithFollowup(
         target: keyBytes,
         queryFn: (peer) async {
-          _logger.fine('Sending GET_VALUE to ${peer.toBase58().substring(0, 6)} for search');
-          
+          _logger.fine(
+              'Sending GET_VALUE to ${peer.toBase58().substring(0, 6)} for search');
+
           final message = Message(
             type: MessageType.getValue,
             key: keyBytes,
           );
-          
+
           final response = await _network?.sendMessage(peer, message);
           if (response == null) {
             throw DHTNetworkException('No response from peer', peerId: peer);
           }
-          
+
           // If we found a record, add it to the stream
           if (response.record != null) {
             controller.add(response.record!.value);
           }
-          
-          return response.closerPeers.map((p) => AddrInfo(
-            PeerId.fromBytes(p.id),
-            p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-          )).toList();
+
+          return response.closerPeers
+              .map((p) => AddrInfo(
+                    PeerId.fromBytes(p.id),
+                    p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                  ))
+              .toList();
         },
         stopFn: (peerset) {
-          return peerset.getClosestInStates([PeerState.queried]).length >= (_config?.resiliency ?? 3);
+          return peerset.getClosestInStates([PeerState.queried]).length >=
+              (_config?.resiliency ?? 3);
         },
       );
-      
+
       _logger.info('Search value completed for key: ${key.substring(0, 10)}');
     } catch (e) {
-      _logger.warning('Search value failed for key: ${key.substring(0, 10)}: $e');
+      _logger
+          .warning('Search value failed for key: ${key.substring(0, 10)}: $e');
     } finally {
       controller.close();
     }
   }
 
   /// Asynchronously finds providers for a CID
-  Future<void> _findProvidersAsync(Uint8List cidBytes, int count, StreamController<AddrInfo> controller, Set<PeerId> foundProviders) async {
+  Future<void> _findProvidersAsync(Uint8List cidBytes, int count,
+      StreamController<AddrInfo> controller, Set<PeerId> foundProviders) async {
     try {
       // Check local provider store first
       final localProviders = await getLocalProviders(cidBytes);
@@ -473,121 +518,137 @@ class QueryManager {
         if (foundProviders.length >= count) break;
         if (foundProviders.add(provider.id)) {
           controller.add(provider);
-          _logger.fine('Added local provider ${provider.id.toBase58().substring(0, 6)}');
+          _logger.fine(
+              'Added local provider ${provider.id.toBase58().substring(0, 6)}');
         }
       }
-      
+
       // If we have enough providers locally, we can finish
       if (foundProviders.length >= count) {
         controller.close();
         return;
       }
-      
+
       // Perform distributed lookup for providers
       await runLookupWithFollowup(
         target: cidBytes,
         queryFn: (peer) async {
-          _logger.fine('Sending GET_PROVIDERS to ${peer.toBase58().substring(0, 6)}');
-          
+          _logger.fine(
+              'Sending GET_PROVIDERS to ${peer.toBase58().substring(0, 6)}');
+
           final message = Message(
             type: MessageType.getProviders,
             key: cidBytes,
           );
-          
+
           final response = await _network?.sendMessage(peer, message);
           if (response == null) {
             throw DHTNetworkException('No response from peer', peerId: peer);
           }
-          
+
           // Add any providers found in the response
           for (final providerPeer in response.providerPeers) {
             if (foundProviders.length >= count) break;
-            
+
             final providerId = PeerId.fromBytes(providerPeer.id);
             if (foundProviders.add(providerId)) {
               final providerInfo = AddrInfo(
                 providerId,
-                providerPeer.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                providerPeer.addrs
+                    .map((addr) => MultiAddr.fromBytes(addr))
+                    .toList(),
               );
               controller.add(providerInfo);
-              _logger.fine('Found provider ${providerId.toBase58().substring(0, 6)} from ${peer.toBase58().substring(0, 6)}');
+              _logger.fine(
+                  'Found provider ${providerId.toBase58().substring(0, 6)} from ${peer.toBase58().substring(0, 6)}');
             }
           }
-          
+
           // Return closer peers for continued lookup
-          return response.closerPeers.map((p) => AddrInfo(
-            PeerId.fromBytes(p.id),
-            p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-          )).toList();
+          return response.closerPeers
+              .map((p) => AddrInfo(
+                    PeerId.fromBytes(p.id),
+                    p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                  ))
+              .toList();
         },
         stopFn: (peerset) {
           // Stop when we have enough providers or queried enough peers
-          return foundProviders.length >= count || 
-                 peerset.getClosestInStates([PeerState.queried]).length >= (_config?.resiliency ?? 3);
+          return foundProviders.length >= count ||
+              peerset.getClosestInStates([PeerState.queried]).length >=
+                  (_config?.resiliency ?? 3);
         },
       );
-      
-      _logger.info('Distributed provider search completed. Found ${foundProviders.length} providers');
+
+      _logger.info(
+          'Distributed provider search completed. Found ${foundProviders.length} providers');
     } catch (e) {
       _logger.warning('Provider search failed: $e');
     } finally {
       controller.close();
     }
   }
-  
+
   /// Provides a CID to the DHT
   Future<void> provide(CID cid, bool announce) async {
     _ensureStarted();
-    
+
     final stopwatch = Stopwatch()..start();
     _metrics?.recordQueryStart();
-    
+
     try {
       _logger.info('Providing CID ${cid.toString().substring(0, 10)}...');
-      
-      final cidBytes = cid.toBytes();
-      
+
+      final cidBytes = cid.multihash;
+
       // Add ourselves as a provider locally
       final selfInfo = AddrInfo(_network!.host.id, []);
       await addProvider(cidBytes, selfInfo);
-      
+
       if (announce) {
         // Find closest peers to announce to
         final result = await runLookupWithFollowup(
           target: cidBytes,
           queryFn: (peer) async {
-            _logger.fine('Sending FIND_NODE to ${peer.toBase58().substring(0, 6)} for provider announcement');
-            
+            _logger.fine(
+                'Sending FIND_NODE to ${peer.toBase58().substring(0, 6)} for provider announcement');
+
             final message = Message(
               type: MessageType.findNode,
               key: cidBytes,
             );
-            
+
             final response = await _network?.sendMessage(peer, message);
             if (response == null) {
               throw DHTNetworkException('No response from peer', peerId: peer);
             }
-            
-            return response.closerPeers.map((p) => AddrInfo(
-              PeerId.fromBytes(p.id),
-              p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
-            )).toList();
+
+            return response.closerPeers
+                .map((p) => AddrInfo(
+                      PeerId.fromBytes(p.id),
+                      p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList(),
+                    ))
+                .toList();
           },
           stopFn: (peerset) {
-            return peerset.getClosestInStates([PeerState.queried]).length >= (_config?.resiliency ?? 3);
+            return peerset.getClosestInStates([PeerState.queried]).length >=
+                (_config?.resiliency ?? 3);
           },
         );
-        
+
         // Announce to closest peers
         final announcePeers = result.peers.take(_config?.resiliency ?? 3);
         var successCount = 0;
-        
+
         for (final peer in announcePeers) {
           try {
             // Get our own addresses from peerstore
-            final peerInfo = await _network?.host.peerStore.getPeer(_network!.host.id);
-            final ourAddrs = peerInfo?.addrs.map((addr) => addr.toBytes()).toList() ?? <Uint8List>[];
-            
+            final peerInfo =
+                await _network?.host.peerStore.getPeer(_network!.host.id);
+            final ourAddrs =
+                peerInfo?.addrs.map((addr) => addr.toBytes()).toList() ??
+                    <Uint8List>[];
+
             final addProviderMessage = Message(
               type: MessageType.addProvider,
               key: cidBytes,
@@ -599,21 +660,24 @@ class QueryManager {
                 ),
               ],
             );
-            
+
             await _network?.sendMessageFireAndForget(peer, addProviderMessage);
             successCount++;
-            _logger.fine('Successfully announced provider to ${peer.toBase58().substring(0, 6)}');
+            _logger.fine(
+                'Successfully announced provider to ${peer.toBase58().substring(0, 6)}');
           } catch (e) {
-            _logger.warning('Failed to announce provider to ${peer.toBase58().substring(0, 6)}: $e');
+            _logger.warning(
+                'Failed to announce provider to ${peer.toBase58().substring(0, 6)}: $e');
           }
         }
-        
-        _logger.info('Provider announcement completed. Successfully announced to $successCount/${announcePeers.length} peers');
+
+        _logger.info(
+            'Provider announcement completed. Successfully announced to $successCount/${announcePeers.length} peers');
       }
-      
+
       stopwatch.stop();
       _metrics?.recordQuerySuccess(stopwatch.elapsed);
-      
+
       _logger.info('CID provided successfully');
     } catch (e) {
       stopwatch.stop();
@@ -622,72 +686,78 @@ class QueryManager {
       rethrow;
     }
   }
-  
+
   /// Adds a provider to the DHT
   Future<void> addProvider(Uint8List key, AddrInfo provider) async {
     _ensureStarted();
-    
-    _logger.info('Adding provider ${provider.id.toBase58().substring(0, 6)}...');
-    
+
+    _logger
+        .info('Adding provider ${provider.id.toBase58().substring(0, 6)}...');
+
     try {
       // Store provider addresses in peerstore
-      _network?.host.peerStore.addOrUpdatePeer(provider.id, addrs: provider.addrs);
-      
+      _network?.host.peerStore
+          .addOrUpdatePeer(provider.id, addrs: provider.addrs);
+
       // Store provider in local provider store
       final cid = CID.fromBytes(key);
       await _providerStore?.addProvider(cid, provider);
-      
+
       _metrics?.recordProviderStored();
-      _logger.fine('Provider ${provider.id.toBase58().substring(0, 6)} added successfully');
+      _logger.fine(
+          'Provider ${provider.id.toBase58().substring(0, 6)} added successfully');
     } catch (e) {
-      _logger.warning('Failed to add provider ${provider.id.toBase58().substring(0, 6)}: $e');
+      _logger.warning(
+          'Failed to add provider ${provider.id.toBase58().substring(0, 6)}: $e');
       rethrow;
     }
   }
-  
+
   /// Gets local providers for a key
   Future<List<AddrInfo>> getLocalProviders(Uint8List key) async {
     _ensureStarted();
-    
+
     _logger.fine('Getting local providers for key...');
-    
+
     try {
       // Get providers from the local provider store
       final cid = CID.fromBytes(key);
       final providers = await _providerStore?.getProviders(cid) ?? [];
-      
+
       _metrics?.recordProviderRetrieved();
       _logger.fine('Found ${providers.length} local providers for key');
-      
+
       return providers;
     } catch (e) {
       _logger.warning('Failed to get local providers: $e');
       return [];
     }
   }
-  
+
   /// Advertises a namespace
-  Future<Duration> advertise(String ns, [List<DiscoveryOption> options = const []]) async {
+  Future<Duration> advertise(String ns,
+      [List<DiscoveryOption> options = const []]) async {
     _ensureStarted();
-    
+
     _logger.info('Advertising namespace: $ns');
-    
+
     // Simplified implementation - would normally advertise to network
     return Duration(minutes: 1);
   }
-  
+
   /// Finds peers in a namespace
-  Future<Stream<AddrInfo>> findPeers(String ns, [List<DiscoveryOption> options = const []]) async {
+  Future<Stream<AddrInfo>> findPeers(String ns,
+      [List<DiscoveryOption> options = const []]) async {
     _ensureStarted();
-    
+
     _logger.info('Finding peers in namespace: $ns');
-    
+
     // Simplified implementation - would normally query network
     final emptyController = StreamController<AddrInfo>();
     emptyController.close();
     return emptyController.stream;
   }
-  
+
   /// Runs a lookup with followup - core DHT operation
   Future<LookupWithFollowupResult> runLookupWithFollowup({
     required Uint8List target,
@@ -695,19 +765,24 @@ class QueryManager {
     required bool Function(QueryPeerset peerset) stopFn,
   }) async {
     _ensureStarted();
-    
+
     final id = _network?.host.id.toBase58();
-    final logPrefix = '[${id?.substring((id.length - 6).clamp(0, id.length)) ?? 'unknown'}.runLookupWithFollowup]';
-    _logger.info('$logPrefix Starting lookup for target: ${target.take(10).toList()}...');
+    final logPrefix =
+        '[${id?.substring((id.length - 6).clamp(0, id.length)) ?? 'unknown'}.runLookupWithFollowup]';
+    _logger.info(
+        '$logPrefix Starting lookup for target: ${target.take(10).toList()}...');
 
     // Get bootstrap peers for the query from routing table
     var queryPeers = await _routing?.getBootstrapPeers() ?? [];
-    
+
     // FALLBACK: Use configured bootstrap peers if routing table is empty
     // This is critical for DHT client mode where routing table may be sparse
-    if (queryPeers.isEmpty && _config?.bootstrapPeers != null && _config!.bootstrapPeers!.isNotEmpty) {
-      _logger.info('$logPrefix Routing table empty, falling back to ${_config!.bootstrapPeers!.length} configured bootstrap peers');
-      
+    if (queryPeers.isEmpty &&
+        _config?.bootstrapPeers != null &&
+        _config!.bootstrapPeers!.isNotEmpty) {
+      _logger.info(
+          '$logPrefix Routing table empty, falling back to ${_config!.bootstrapPeers!.length} configured bootstrap peers');
+
       final configuredPeers = <AddrInfo>[];
       for (final ma in _config!.bootstrapPeers!) {
         try {
@@ -715,24 +790,27 @@ class QueryManager {
           if (peerIdStr != null) {
             final peerId = PeerId.fromString(peerIdStr);
             configuredPeers.add(AddrInfo(peerId, [ma]));
-            _logger.fine('$logPrefix Using configured bootstrap peer: ${peerId.toBase58().substring(0, 8)}...');
+            _logger.fine(
+                '$logPrefix Using configured bootstrap peer: ${peerId.toBase58().substring(0, 8)}...');
           }
         } catch (e) {
-          _logger.warning('$logPrefix Failed to parse bootstrap multiaddr $ma: $e');
+          _logger.warning(
+              '$logPrefix Failed to parse bootstrap multiaddr $ma: $e');
         }
       }
       queryPeers = configuredPeers;
     }
-    
+
     if (queryPeers.isEmpty) {
-      _logger.warning('$logPrefix No bootstrap peers available for lookup (neither from routing table nor config)');
+      _logger.warning(
+          '$logPrefix No bootstrap peers available for lookup (neither from routing table nor config)');
       return LookupWithFollowupResult(
         peers: [],
         terminationReason: LookupTerminationReason.noMorePeers,
         errors: [],
       );
     }
-    
+
     _logger.info('$logPrefix Using ${queryPeers.length} peers for DHT query');
 
     // Create QueryRunner with our configuration
@@ -748,19 +826,27 @@ class QueryManager {
     try {
       // Run the query
       final result = await runner.run();
-      
-      _logger.info('$logPrefix Query completed with reason: ${result.reason}. Found ${result.peerset.getClosestInStates([PeerState.queried, PeerState.heard]).length} peers');
+
+      _logger.info(
+          '$logPrefix Query completed with reason: ${result.reason}. Found ${result.peerset.getClosestInStates([
+            PeerState.queried,
+            PeerState.heard
+          ]).length} peers');
 
       // Handle peer eviction for failed queries
-      final unreachablePeers = result.peerset.getClosestInStates([PeerState.unreachable]);
+      final unreachablePeers =
+          result.peerset.getClosestInStates([PeerState.unreachable]);
       if (unreachablePeers.isNotEmpty) {
-        _logger.info('$logPrefix Evicting ${unreachablePeers.length} unreachable peers from routing table');
+        _logger.info(
+            '$logPrefix Evicting ${unreachablePeers.length} unreachable peers from routing table');
         for (final peer in unreachablePeers) {
           try {
             await _routing?.removePeer(peer);
-            _logger.finer('$logPrefix Evicted peer ${peer.toBase58().substring(0,6)} from routing table after failed query');
+            _logger.finer(
+                '$logPrefix Evicted peer ${peer.toBase58().substring(0, 6)} from routing table after failed query');
           } catch (e) {
-            _logger.warning('$logPrefix Failed to evict peer ${peer.toBase58().substring(0,6)} from routing table: $e');
+            _logger.warning(
+                '$logPrefix Failed to evict peer ${peer.toBase58().substring(0, 6)} from routing table: $e');
           }
         }
       }
@@ -803,10 +889,11 @@ class QueryManager {
   }
 
   /// Performs a network query for a specific peer
-  Future<AddrInfo?> _performNetworkQuery(PeerId target, QueryType type, RoutingOptions? options) async {
+  Future<AddrInfo?> _performNetworkQuery(
+      PeerId target, QueryType type, RoutingOptions? options) async {
     final targetShortId = target.toBase58().substring(0, 6);
     _logger.info('Performing network query for $targetShortId (type: $type)');
-    
+
     // Implementation depends on the query type
     switch (type) {
       case QueryType.findPeer:
@@ -827,101 +914,121 @@ class QueryManager {
   }
 
   /// Performs a FIND_PEER query using distributed lookup
-  Future<AddrInfo?> _performFindPeerQuery(PeerId target, RoutingOptions? options) async {
+  Future<AddrInfo?> _performFindPeerQuery(
+      PeerId target, RoutingOptions? options) async {
     final targetBytes = target.toBytes();
     final targetShortId = target.toBase58().substring(0, 6);
-    
+
     final result = await runLookupWithFollowup(
       target: targetBytes,
       queryFn: (peer) async {
-        final queryFnLogPrefix = '[lookup.queryFn for ${peer.toBase58().substring(0,6)}]';
-        _logger.fine('$queryFnLogPrefix Sending FIND_NODE for target $targetShortId');
-        
+        final queryFnLogPrefix =
+            '[lookup.queryFn for ${peer.toBase58().substring(0, 6)}]';
+        _logger.fine(
+            '$queryFnLogPrefix Sending FIND_NODE for target $targetShortId');
+
         final message = Message(
           type: MessageType.findNode,
           key: targetBytes,
         );
-        
+
         final response = await _network?.sendMessage(peer, message);
         if (response == null) {
           throw DHTNetworkException('No response from peer', peerId: peer);
         }
-        
-        _logger.fine('$queryFnLogPrefix Got FIND_NODE response with ${response.closerPeers.length} closer peers');
-        
+
+        _logger.fine(
+            '$queryFnLogPrefix Got FIND_NODE response with ${response.closerPeers.length} closer peers');
+
         // Try adding the queried peer to routing table
         try {
           await _routing?.addPeer(peer, queryPeer: false, isReplaceable: true);
-          _logger.finer('$queryFnLogPrefix Added peer ${peer.toBase58().substring(0,6)} to routing table');
+          _logger.finer(
+              '$queryFnLogPrefix Added peer ${peer.toBase58().substring(0, 6)} to routing table');
         } catch (e) {
-          _logger.warning('$queryFnLogPrefix Failed to add peer to routing table: $e');
+          _logger.warning(
+              '$queryFnLogPrefix Failed to add peer to routing table: $e');
         }
-        
+
         // Check if we found the target peer in the response
         for (final p in response.closerPeers) {
           if (_bytesEqual(p.id, targetBytes)) {
-            _logger.info('$queryFnLogPrefix Target peer $targetShortId found in response');
-            
+            _logger.info(
+                '$queryFnLogPrefix Target peer $targetShortId found in response');
+
             // CRITICAL FIX: Store discovered addresses in peerstore!
             // This ensures addresses are available when we look them up later
             final targetPeerId = PeerId.fromBytes(p.id);
-            final addresses = p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList();
-            
+            final addresses =
+                p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList();
+
             if (addresses.isNotEmpty) {
               try {
-                await _network?.host.peerStore.addOrUpdatePeer(targetPeerId, addrs: addresses);
-                _logger.info('$queryFnLogPrefix Stored ${addresses.length} addresses for target peer $targetShortId in peerstore');
+                await _network?.host.peerStore
+                    .addOrUpdatePeer(targetPeerId, addrs: addresses);
+                _logger.info(
+                    '$queryFnLogPrefix Stored ${addresses.length} addresses for target peer $targetShortId in peerstore');
               } catch (e) {
-                _logger.warning('$queryFnLogPrefix Failed to store addresses for target peer $targetShortId: $e');
+                _logger.warning(
+                    '$queryFnLogPrefix Failed to store addresses for target peer $targetShortId: $e');
               }
             }
-            
+
             return [
               AddrInfo(targetPeerId, addresses),
             ];
           }
         }
-        
+
         // CRITICAL FIX: Store all discovered peer addresses in peerstore
         final result = <AddrInfo>[];
         for (final p in response.closerPeers) {
           final peerId = PeerId.fromBytes(p.id);
-          final addresses = p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList();
-          
+          final addresses =
+              p.addrs.map((addr) => MultiAddr.fromBytes(addr)).toList();
+
           // Store addresses in peerstore for future use
           if (addresses.isNotEmpty) {
             try {
-              await _network?.host.peerStore.addOrUpdatePeer(peerId, addrs: addresses);
-              _logger.finest('$queryFnLogPrefix Stored ${addresses.length} addresses for peer ${peerId.toBase58().substring(0,6)}');
+              await _network?.host.peerStore
+                  .addOrUpdatePeer(peerId, addrs: addresses);
+              _logger.finest(
+                  '$queryFnLogPrefix Stored ${addresses.length} addresses for peer ${peerId.toBase58().substring(0, 6)}');
             } catch (e) {
-              _logger.warning('$queryFnLogPrefix Failed to store addresses for peer ${peerId.toBase58().substring(0,6)}: $e');
+              _logger.warning(
+                  '$queryFnLogPrefix Failed to store addresses for peer ${peerId.toBase58().substring(0, 6)}: $e');
             }
           }
-          
+
           result.add(AddrInfo(peerId, addresses));
         }
         return result;
       },
       stopFn: (peerset) {
         // Stop if we found the target peer
-        for (final p in peerset.getClosestInStates([PeerState.queried, PeerState.waiting, PeerState.heard])) {
+        for (final p in peerset.getClosestInStates(
+            [PeerState.queried, PeerState.waiting, PeerState.heard])) {
           if (_bytesEqual(p.toBytes(), targetBytes)) {
-            _logger.fine('[lookup.stopFn] Target peer $targetShortId found in peerset. Stopping lookup');
+            _logger.fine(
+                '[lookup.stopFn] Target peer $targetShortId found in peerset. Stopping lookup');
             return true;
           }
         }
-        
+
         // Stop when we've queried enough peers
-        final stop = peerset.getClosestInStates([PeerState.queried]).length >= (_config?.resiliency ?? 3);
+        final stop = peerset.getClosestInStates([PeerState.queried]).length >=
+            (_config?.resiliency ?? 3);
         if (stop) {
-          _logger.fine('[lookup.stopFn] Queried enough peers (${_config?.resiliency ?? 3}). Stopping lookup for $targetShortId');
+          _logger.fine(
+              '[lookup.stopFn] Queried enough peers (${_config?.resiliency ?? 3}). Stopping lookup for $targetShortId');
         }
         return stop;
       },
     );
 
-    _logger.info('Lookup for $targetShortId completed. TerminationReason: ${result.terminationReason}. Found ${result.peers.length} peers');
-    
+    _logger.info(
+        'Lookup for $targetShortId completed. TerminationReason: ${result.terminationReason}. Found ${result.peers.length} peers');
+
     // Look for the target peer in the result
     for (final peerId in result.peers) {
       if (_bytesEqual(peerId.toBytes(), targetBytes)) {
@@ -932,7 +1039,7 @@ class QueryManager {
         }
       }
     }
-    
+
     return null;
   }
 
@@ -944,13 +1051,13 @@ class QueryManager {
     }
     return true;
   }
-  
+
   /// Ensures the query manager is started
   void _ensureStarted() {
     if (_closed) throw DHTClosedException();
     if (!_started) throw DHTNotStartedException();
   }
-  
+
   @override
   String toString() => 'QueryManager()';
 }

--- a/lib/src/providers/provider_store.dart
+++ b/lib/src/providers/provider_store.dart
@@ -2,18 +2,17 @@ import 'dart:typed_data';
 
 import 'package:dcid/dcid.dart';
 import 'package:dart_libp2p/core/peer/addr_info.dart';
-import 'package:dart_libp2p/core/routing/routing.dart';
 
 /// ProviderStore represents a store that associates peers and their addresses to keys.
 abstract class ProviderStore {
   /// Adds a provider for the given key
-  /// 
+  ///
   /// The provider will be associated with the key and can be retrieved later
   /// using [getProviders].
   Future<void> addProvider(CID key, AddrInfo provider);
 
   /// Gets providers for the given key
-  /// 
+  ///
   /// Returns a list of providers that have been associated with the key
   Future<List<AddrInfo>> getProviders(CID key);
 
@@ -53,10 +52,7 @@ class ProviderRecord {
   final DateTime expiration;
 
   /// Creates a new provider record
-  ProviderRecord({
-    required this.provider,
-    required this.expiration,
-  });
+  ProviderRecord({required this.provider, required this.expiration});
 
   /// Checks if this record has expired
   bool isExpired() {
@@ -79,31 +75,13 @@ class MemoryProviderStore implements ProviderStore {
       throw StateError('Provider store is closed');
     }
 
-    final keyStr = _keyToString(key.toBytes());
-    
-    // 🔍 DIAGNOSTIC LOGGING
-    print('🔍 [ProviderStore.addProvider] ═══════════════════════════════');
-    print('🔍 CID (toString): ${key.toString()}');
-    print('🔍 CID (bytes hex): ${key.toBytes().map((b) => b.toRadixString(16).padLeft(2, '0')).join(' ')}');
-    print('🔍 Key string length: ${keyStr.length}');
-    print('🔍 Provider Peer ID: ${provider.id.toBase58()}');
-    print('🔍 Provider Addresses: ${provider.addrs.map((a) => a.toString()).join(", ")}');
-    
+    final keyStr = _keyToString(key.multihash);
+
     final expiration = DateTime.now().add(_options.provideValidity);
-    final record = ProviderRecord(
-      provider: provider,
-      expiration: expiration,
-    );
+    final record = ProviderRecord(provider: provider, expiration: expiration);
 
     _providers.putIfAbsent(keyStr, () => []).add(record);
     _cleanupExpired(keyStr);
-    
-    print('🔍 Total providers for this CID: ${_providers[keyStr]!.length}');
-    print('🔍 All providers for this CID:');
-    for (final r in _providers[keyStr]!) {
-      print('🔍   - ${r.provider.id.toBase58()}');
-    }
-    print('🔍 ═══════════════════════════════════════════════════════════');
   }
 
   @override
@@ -112,25 +90,11 @@ class MemoryProviderStore implements ProviderStore {
       throw StateError('Provider store is closed');
     }
 
-    final keyStr = _keyToString(key.toBytes());
-    
-    // 🔍 DIAGNOSTIC LOGGING
-    print('🔍 [ProviderStore.getProviders] ═══════════════════════════════');
-    print('🔍 CID (toString): ${key.toString()}');
-    print('🔍 CID (bytes hex): ${key.toBytes().map((b) => b.toRadixString(16).padLeft(2, '0')).join(' ')}');
-    print('🔍 Key string length: ${keyStr.length}');
-    print('🔍 Looking up key in store...');
-    
+    final keyStr = _keyToString(key.multihash);
+
     _cleanupExpired(keyStr);
 
     final records = _providers[keyStr] ?? [];
-    
-    print('🔍 Found ${records.length} provider(s) for this CID:');
-    for (final record in records) {
-      print('🔍   - ${record.provider.id.toBase58()} (expires: ${record.expiration})');
-    }
-    print('🔍 ═══════════════════════════════════════════════════════════');
-    
     final result = records.map((record) => record.provider).toList();
     return result;
   }
@@ -146,7 +110,8 @@ class MemoryProviderStore implements ProviderStore {
     final records = _providers[key];
     if (records == null) return;
 
-    final validRecords = records.where((record) => !record.isExpired()).toList();
+    final validRecords =
+        records.where((record) => !record.isExpired()).toList();
     if (validRecords.isEmpty) {
       _providers.remove(key);
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_libp2p_kad_dht
 description: A comprehensive Dart implementation of the libp2p Kademlia DHT with modular architecture, built-in observability, and production-ready features. Features IpfsDHTv2 with enhanced performance, error handling, and monitoring capabilities.
-version: 1.2.0
+version: 1.2.1
 repository: https://github.com/stephanfeb/dart_libp2p_kad_dht
 homepage: https://github.com/stephanfeb/dart_libp2p_kad_dht
 documentation: https://github.com/stephanfeb/dart_libp2p_kad_dht/blob/main/DEVELOPER_GUIDE.md


### PR DESCRIPTION
## Summary

This change fixes several DHT interoperability issues found while querying Go/libp2p Kademlia peers from Dart.

## Changes

- DHT provider operations now use the CID multihash (`cid.multihash`) as the provider key instead of full CID bytes (`cid.toBytes()`).
- `MemoryProviderStore` stores and looks up providers by multihash, so equivalent CID versions resolve to the same provider records.
- `GET_PROVIDERS`, `FIND_NODE`, and `ADD_PROVIDER` provider paths in both the legacy DHT and v2 query manager now use the multihash key expected by Go/libp2p.
- DHT response reading now reads the complete varint-length-prefixed protobuf frame instead of assuming a single stream read contains the full frame.
- Provider records without embedded addresses are preserved by callers instead of being treated as invalid; addresses can be resolved from peerstore, bootstrap configuration, or an already established connection.
- The protocol path handles RSA/public DHT peers more reliably when combined with the peer ID parser fix in `dart_libp2p`.

## Why

Go/libp2p indexes provider records by `cid.Hash()` rather than the serialized CID. Using full CID bytes creates a different DHT key, so Dart nodes can publish and find themselves while missing Go/libp2p providers for the same logical content key.

Real DHT streams also do not guarantee that one `read()` returns a full protobuf frame. Reading only once can fail with partial frame data or decode errors.

Provider responses may legally contain provider peer IDs with no addresses. Dropping those records prevents callers from using addresses that are already known from the peerstore or bootstrap list.

## Validation

- Verified against Go/libp2p DHT nodes advertising the same discovery key.
- Confirmed `GET_PROVIDERS` responses now include Go provider peer IDs for the shared key.
- Ran focused provider store tests.
